### PR TITLE
HTTP Request Shortcuts 的链接与 Autox.js 保持一致，使用 GitHub 仓库的链接

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ docker compose up -d
 - 自动同步，导入这个[快捷指令](https://www.icloud.com/shortcuts/542ad23b33314b36807c05a5d8aa5c22)，运行后设备会自动在后台同步剪贴板内容，此快捷指令将执行无限时长，需要手动关闭，你还可以手动修改同步后是否发送系统通知、查询的间隔秒数
 
 ### Android
-#### 使用[HTTP Request Shortcuts](https://play.google.com/store/apps/details?id=ch.rmy.android.http_shortcuts)
+#### 使用[HTTP Request Shortcuts](https://github.com/Waboodoo/HTTP-Shortcuts)
 导入这个[配置文件](/script/shortcuts.zip)，修改`变量`中的`UserName`，`UserToken`，`url`， `url`不要以斜线分隔符`/`结尾。`HTTP Request Shortcuts`支持从下拉菜单、桌面组件、桌面图标、分享菜单中使用
 
 <details>

--- a/docs/README_EN.md
+++ b/docs/README_EN.md
@@ -151,7 +151,7 @@ Notes:
 - Sync Automatically, import this [Shortcut](https://www.icloud.com/shortcuts/542ad23b33314b36807c05a5d8aa5c22). This shortcut keeps running in the background forever, you need to stop it manually. You can also change whether to send notifications and querying interval time manullay.
 
 ### Android
-#### Use [HTTP Request Shortcuts](https://play.google.com/store/apps/details?id=ch.rmy.android.http_shortcuts)
+#### Use [HTTP Request Shortcuts](https://github.com/Waboodoo/HTTP-Shortcuts)
 Import this [file](/script/en/shortcuts.zip), Change the `UserName`, `UserToken`, `url` in `Variables` to yours. Make sure no slash(/) at the end of url. `HTTP Request Shortcuts` supports using shortcuts from drop-down menu, home screen widgets, home screen icons and share sheet.
 
 <details>


### PR DESCRIPTION
在 Releases 可以直接下载安装，为无法使用 Google Play 的用户提供便利。

并且该仓库里也有指向同一个 Google Play 应用的链接：

![image](https://github.com/Jeric-X/SyncClipboard/assets/78434827/d4b0b274-e742-4530-afb5-b844b294b0ac)
