### PR TITLE
fix: 修复连续截图和复制导致的剪贴板无响应

### DIFF
--- a/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
+++ b/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
@@ -85,12 +85,6 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
 
         try
         {
-            // WinUI raises ContentChanged while Clipboard.Flush() is still running and
-            // pumps dispatcher callbacks during the native call. Wait for the local
-            // write to finish before reading to avoid re-entering WinRT clipboard APIs.
-            await LocalClipboard.Semaphore.WaitAsync(token);
-            using var localClipboardGuard = new ScopeGuard(() => LocalClipboard.Semaphore.Release());
-
             ClipboardChangedImpl?.GetInvocationList()?.ForEach(delegt => delegt.InvokeNoExcept());
             meta ??= await ClipboardFactory.GetMetaInfomation(token);
             var profile = await ClipboardFactory.CreateProfileFromMeta(meta, token);

--- a/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
+++ b/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
@@ -1,17 +1,14 @@
 ﻿using SyncClipboard.Core.Interfaces;
 using SyncClipboard.Core.Models;
 using SyncClipboard.Core.Utilities;
-using SyncClipboard.Core.Utilities.Runner;
 
 namespace SyncClipboard.Core.Clipboard;
 
 public abstract class ClipboardChangingListenerBase : IClipboardChangingListener, IClipboardMoniter, IDisposable
 {
-    private static readonly TimeSpan ClipboardChangeDebounceDelay = TimeSpan.FromMilliseconds(50);
     private static readonly TimeSpan ClipboardReadTimeout = TimeSpan.FromSeconds(10);
 
     private bool _registed = false;
-    private readonly SingletonTask _notifyTask = new();
 
     protected delegate void MetaChanged(ClipboardMetaInfomation? meta);
     protected abstract void RegistSystemEvent(MetaChanged action);
@@ -81,32 +78,23 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
         return ClipboardChangedImpl?.GetInvocationList().Length > 0 || ChangedImpl?.GetInvocationList().Length > 0;
     }
 
-    private void NotifyAll(ClipboardMetaInfomation? meta)
+    private async void NotifyAll(ClipboardMetaInfomation? meta)
     {
-        _ = _notifyTask.Run(token => NotifyAllAsync(meta, token));
-    }
+        using var cancellationSource = new CancellationTokenSource(ClipboardReadTimeout);
+        var token = cancellationSource.Token;
 
-    private async Task NotifyAllAsync(ClipboardMetaInfomation? meta, CancellationToken pendingToken)
-    {
         try
         {
-            // WinUI may raise ContentChanged synchronously from Clipboard.Flush().
-            // Always leave the native callback before reading the clipboard to avoid
-            // re-entering WinRT clipboard APIs on the same UI stack. The short delay
-            // also coalesces bursts such as consecutive screenshots.
-            await Task.Delay(ClipboardChangeDebounceDelay, pendingToken);
+            // WinUI raises ContentChanged while Clipboard.Flush() is still running and
+            // pumps dispatcher callbacks during the native call. Wait for the local
+            // write to finish before reading to avoid re-entering WinRT clipboard APIs.
+            await LocalClipboard.Semaphore.WaitAsync(token);
+            using var localClipboardGuard = new ScopeGuard(() => LocalClipboard.Semaphore.Release());
 
             ClipboardChangedImpl?.GetInvocationList()?.ForEach(delegt => delegt.InvokeNoExcept());
-            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(pendingToken);
-            cancellationSource.CancelAfter(ClipboardReadTimeout);
-            var token = cancellationSource.Token;
             meta ??= await ClipboardFactory.GetMetaInfomation(token);
             var profile = await ClipboardFactory.CreateProfileFromMeta(meta, token);
             ChangedImpl?.GetInvocationList()?.ForEach(delegt => delegt.InvokeNoExcept(meta, profile));
-        }
-        catch (OperationCanceledException) when (pendingToken.IsCancellationRequested)
-        {
-            throw;
         }
         catch (Exception ex)
         {
@@ -118,7 +106,6 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
 
     public void Dispose()
     {
-        _notifyTask.Cancel();
         ChangedImpl = null;
         UnRegistSystemEvent(NotifyAll);
         GC.SuppressFinalize(this);

--- a/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
+++ b/src/SyncClipboard.Core/Clipboard/ClipboardChangingListenerBase.cs
@@ -1,12 +1,17 @@
 ﻿using SyncClipboard.Core.Interfaces;
 using SyncClipboard.Core.Models;
 using SyncClipboard.Core.Utilities;
+using SyncClipboard.Core.Utilities.Runner;
 
 namespace SyncClipboard.Core.Clipboard;
 
 public abstract class ClipboardChangingListenerBase : IClipboardChangingListener, IClipboardMoniter, IDisposable
 {
+    private static readonly TimeSpan ClipboardChangeDebounceDelay = TimeSpan.FromMilliseconds(50);
+    private static readonly TimeSpan ClipboardReadTimeout = TimeSpan.FromSeconds(10);
+
     private bool _registed = false;
+    private readonly SingletonTask _notifyTask = new();
 
     protected delegate void MetaChanged(ClipboardMetaInfomation? meta);
     protected abstract void RegistSystemEvent(MetaChanged action);
@@ -18,8 +23,8 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
     {
         add
         {
-            AddRef();
             ChangedImpl += value;
+            AddRef();
         }
         remove
         {
@@ -33,8 +38,8 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
     {
         add
         {
-            AddRef();
             ClipboardChangedImpl += value;
+            AddRef();
         }
         remove
         {
@@ -76,26 +81,44 @@ public abstract class ClipboardChangingListenerBase : IClipboardChangingListener
         return ClipboardChangedImpl?.GetInvocationList().Length > 0 || ChangedImpl?.GetInvocationList().Length > 0;
     }
 
-    private MetaChanged NotifyAll => async (meta) =>
+    private void NotifyAll(ClipboardMetaInfomation? meta)
+    {
+        _ = _notifyTask.Run(token => NotifyAllAsync(meta, token));
+    }
+
+    private async Task NotifyAllAsync(ClipboardMetaInfomation? meta, CancellationToken pendingToken)
     {
         try
         {
+            // WinUI may raise ContentChanged synchronously from Clipboard.Flush().
+            // Always leave the native callback before reading the clipboard to avoid
+            // re-entering WinRT clipboard APIs on the same UI stack. The short delay
+            // also coalesces bursts such as consecutive screenshots.
+            await Task.Delay(ClipboardChangeDebounceDelay, pendingToken);
+
             ClipboardChangedImpl?.GetInvocationList()?.ForEach(delegt => delegt.InvokeNoExcept());
-            var token = new CancellationTokenSource(TimeSpan.FromSeconds(10)).Token;
+            using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(pendingToken);
+            cancellationSource.CancelAfter(ClipboardReadTimeout);
+            var token = cancellationSource.Token;
             meta ??= await ClipboardFactory.GetMetaInfomation(token);
             var profile = await ClipboardFactory.CreateProfileFromMeta(meta, token);
             ChangedImpl?.GetInvocationList()?.ForEach(delegt => delegt.InvokeNoExcept(meta, profile));
+        }
+        catch (OperationCanceledException) when (pendingToken.IsCancellationRequested)
+        {
+            throw;
         }
         catch (Exception ex)
         {
             AppCore.Current?.Logger.Write($"Clipboard handler unhandled exception {ex.Message}\n{ex.StackTrace}");
         }
-    };
+    }
 
     ~ClipboardChangingListenerBase() => Dispose();
 
     public void Dispose()
     {
+        _notifyTask.Cancel();
         ChangedImpl = null;
         UnRegistSystemEvent(NotifyAll);
         GC.SuppressFinalize(this);

--- a/src/SyncClipboard.Core/Clipboard/NativeClipboardAccess.cs
+++ b/src/SyncClipboard.Core/Clipboard/NativeClipboardAccess.cs
@@ -1,0 +1,14 @@
+namespace SyncClipboard.Core.Clipboard;
+
+public static class NativeClipboardAccess
+{
+    // Native clipboard APIs may raise change events while a write is still in progress.
+    // Serialize reads and writes to prevent those events from re-entering the clipboard.
+    public static SemaphoreSlim Semaphore { get; } = new(1, 1);
+
+    public static async Task<ScopeGuard> AcquireAsync(CancellationToken cancellationToken)
+    {
+        await Semaphore.WaitAsync(cancellationToken);
+        return new ScopeGuard(() => Semaphore.Release());
+    }
+}

--- a/src/SyncClipboard.Core/UserServices/ClipboardService/EasyCopyImageSerivce.cs
+++ b/src/SyncClipboard.Core/UserServices/ClipboardService/EasyCopyImageSerivce.cs
@@ -52,8 +52,13 @@ public partial class EasyCopyImageSerivce : ClipboardHander
     protected override CancellationToken StopPreviousAndGetNewToken()
     {
         TrayIcon.SetStatusString(SERVICE_NAME, RUNNING_STATUS);
-        _progress?.CancelSicent();
-        _progress = null;
+        ProgressToastReporter? progress;
+        lock (_progressLocker)
+        {
+            progress = _progress;
+            _progress = null;
+        }
+        progress?.CancelSicent();
         return base.StopPreviousAndGetNewToken();
     }
 
@@ -234,9 +239,10 @@ public partial class EasyCopyImageSerivce : ClipboardHander
     private async Task<string> DownloadImage(Uri imageUri, CancellationToken token)
     {
         using var downloadingCts = new CancellationTokenSource();
-        var linkedToken = CancellationTokenSource.CreateLinkedTokenSource(token, downloadingCts.Token).Token;
+        using var linkedCts = CancellationTokenSource.CreateLinkedTokenSource(token, downloadingCts.Token);
 
         var filename = RegexFilename().Match(imageUri.LocalPath);
+        ProgressToastReporter progress;
         lock (_progressLocker)
         {
             _progress ??= new ProgressToastReporter(
@@ -245,11 +251,26 @@ public partial class EasyCopyImageSerivce : ClipboardHander
                 I18n.Strings.DownloadingWebImage,
                 buttons: new ActionButton(I18n.Strings.Cancel, downloadingCts.Cancel)
             );
+            progress = _progress;
         }
 
         var fullPath = Path.Combine(Env.TemplateFileFolder, filename.Value);
-        await Http.GetFile(imageUri.AbsoluteUri, fullPath, _progress, linkedToken);
-        return fullPath;
+        try
+        {
+            await Http.GetFile(imageUri.AbsoluteUri, fullPath, progress, linkedCts.Token);
+            return fullPath;
+        }
+        finally
+        {
+            lock (_progressLocker)
+            {
+                if (ReferenceEquals(_progress, progress))
+                {
+                    _progress = null;
+                }
+            }
+            progress.CancelSicent();
+        }
     }
 
     [GeneratedRegex("[^/]+(?!.*/)")]

--- a/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
+++ b/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
@@ -53,14 +53,17 @@ public class ProgressToastReporter : IProgress<HttpDownloadProgress>
             return;
         }
 
-        double? percentNullable = (double)_progress.BytesReceived / _progress.TotalBytesToReceive;
-        if (!percentNullable.HasValue || double.IsNaN(percentNullable.Value) ||
-            percentNullable.Value <= 0.01)
+        if (!_progress.TotalBytesToReceive.HasValue || _progress.TotalBytesToReceive.Value == 0)
         {
             return;
         }
 
-        double percent = percentNullable.Value;
+        double percent = (double)_progress.BytesReceived / _progress.TotalBytesToReceive.Value;
+        if (percent <= 0.01)
+        {
+            return;
+        }
+
         if (UseTrayIcon)
         {
             UpdateTrayIcon(percent);

--- a/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
+++ b/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
@@ -47,6 +47,17 @@ public class ProgressToastReporter : IProgress<HttpDownloadProgress>
 
     private void UpdateProgress()
     {
+        if (_progress.End)
+        {
+            _counter.Cancle();
+            if (UseToast)
+            {
+                ArgumentNullException.ThrowIfNull(_progressBar);
+                _progressBar.Remove();
+            }
+            return;
+        }
+
         double? percentNullable = (double)_progress.BytesReceived / _progress.TotalBytesToReceive;
         if (!percentNullable.HasValue || double.IsNaN(percentNullable.Value) ||
             percentNullable.Value <= 0.01)
@@ -80,15 +91,7 @@ public class ProgressToastReporter : IProgress<HttpDownloadProgress>
         _progressBar.ProgressValueTip = percent.ToString("P");
         //_progressBar.ProgressTitle = percent.ToString("P");
 
-        if (_progress.End)
-        {
-            _counter.Cancle();
-            if (UseToast)
-            {
-                _progressBar.Remove();
-            }
-        }
-        else if (_progressBar.IsIndeterminate)
+        if (_progressBar.IsIndeterminate)
         {
             if (UseToast)
             {

--- a/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
+++ b/src/SyncClipboard.Core/UserServices/SyncService/ProgressToastReporter.cs
@@ -50,11 +50,6 @@ public class ProgressToastReporter : IProgress<HttpDownloadProgress>
         if (_progress.End)
         {
             _counter.Cancle();
-            if (UseToast)
-            {
-                ArgumentNullException.ThrowIfNull(_progressBar);
-                _progressBar.Remove();
-            }
             return;
         }
 

--- a/src/SyncClipboard.Core/Utilities/Runner/SingletonTask.cs
+++ b/src/SyncClipboard.Core/Utilities/Runner/SingletonTask.cs
@@ -32,7 +32,7 @@ public class SingletonTask
 
     public async Task Run(CancelableTask task, bool cancelPrevious, CancellationToken? token = null)
     {
-        CancellationTokenSource methodLevelCts;
+        CancellationToken methodLevelToken;
         CancellationTokenSource linkedCts;
 
         lock (_ctsLock)
@@ -42,22 +42,25 @@ public class SingletonTask
                 return;
             }
 
-            _cts.Cancel();
+            var previousCts = _cts;
+            previousCts.Cancel();
+            previousCts.Dispose();
+
             _cts = new CancellationTokenSource();
-            methodLevelCts = _cts;
+            methodLevelToken = _cts.Token;
             _task = task;
-            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(_cts.Token, token ?? CancellationToken.None);
+            linkedCts = CancellationTokenSource.CreateLinkedTokenSource(methodLevelToken, token ?? CancellationToken.None);
         }
 
-        try
+        using (linkedCts)
         {
-            await _taskSemaphore.WaitAsync(linkedCts.Token);
-            using var scopeGuard = new ScopeGuard(() => _taskSemaphore.Release());
-            await task(linkedCts.Token);
-        }
-        catch when (methodLevelCts.Token.IsCancellationRequested)
-        {
-            methodLevelCts.Dispose();
+            try
+            {
+                await _taskSemaphore.WaitAsync(linkedCts.Token);
+                using var scopeGuard = new ScopeGuard(() => _taskSemaphore.Release());
+                await task(linkedCts.Token);
+            }
+            catch when (methodLevelToken.IsCancellationRequested) { }
         }
     }
 

--- a/src/SyncClipboard.Core/Utilities/Web/WebDavBase.cs
+++ b/src/SyncClipboard.Core/Utilities/Web/WebDavBase.cs
@@ -67,7 +67,7 @@ namespace SyncClipboard.Core.Utilities.Web
             SetAuthHeader();
         }
 
-        private HttpClient CreateHttpClient()
+        protected virtual HttpClient CreateHttpClient()
         {
             var httpclientHandler = new HttpClientHandler();
             if (TrustInsecureCertificate)
@@ -102,85 +102,95 @@ namespace SyncClipboard.Core.Utilities.Web
                 = new AuthenticationHeaderValue("Basic", Convert.ToBase64String(bytes));
         }
 
-        public Task GetFile(string url, string localFilePath, CancellationToken? cancelToken = null)
+        public async Task GetFile(string url, string localFilePath, CancellationToken? cancelToken = null)
         {
-            return HttpClient.GetFile(url, localFilePath, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            await HttpClient.GetFile(url, localFilePath, cancellationSource.Token);
         }
 
-        public Task GetFile(string url, string localFilePath, IProgress<HttpDownloadProgress>? progress = null,
+        public async Task GetFile(string url, string localFilePath, IProgress<HttpDownloadProgress>? progress = null,
             CancellationToken? cancelToken = null)
         {
-            return HttpClient.GetFile(url, localFilePath, progress, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            await HttpClient.GetFile(url, localFilePath, progress, cancellationSource.Token);
         }
 
         public async Task PutFile(string url, string localFilePath, CancellationToken? cancelToken = null)
         {
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
             using var fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using var streamContent = new StreamContent(fileStream);
-            await HttpClient.PutAsync(url, streamContent, AdjustCancelToken(cancelToken));
+            using var response = await HttpClient.PutAsync(url, streamContent, cancellationSource.Token);
         }
 
         public async Task PutFile(string url, string localFilePath, IProgress<HttpDownloadProgress>? progress, CancellationToken? cancelToken = null)
         {
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
             using var fileStream = new FileStream(localFilePath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite);
             using HttpContent streamContent = progress is null
                 ? new StreamContent(fileStream)
-                : new ProgressableStreamContent(fileStream, progress, AdjustCancelToken(cancelToken));
-            await HttpClient.PutAsync(url, streamContent, AdjustCancelToken(cancelToken));
+                : new ProgressableStreamContent(fileStream, progress, cancellationSource.Token);
+            using var response = await HttpClient.PutAsync(url, streamContent, cancellationSource.Token);
         }
 
-        public Task<string> GetText(string url, CancellationToken? cancelToken = null)
+        public async Task<string> GetText(string url, CancellationToken? cancelToken = null)
         {
-            return HttpClient.GetStringAsync(url, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            return await HttpClient.GetStringAsync(url, cancellationSource.Token);
         }
 
         public async Task PutText(string url, string text, CancellationToken? cancelToken = null)
         {
-            var res = await HttpClient.PutAsync(url, new StringContent(text), AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var content = new StringContent(text);
+            using var res = await HttpClient.PutAsync(url, content, cancellationSource.Token);
             res.EnsureSuccessStatusCode();
         }
 
-        public Task<Type?> GetJson<Type>(string url, CancellationToken? cancelToken = null)
+        public async Task<Type?> GetJson<Type>(string url, CancellationToken? cancelToken = null)
         {
-            return HttpClient.GetFromJsonAsync<Type>(
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            return await HttpClient.GetFromJsonAsync<Type>(
                 url,
                 SerializerOptions,
-                AdjustCancelToken(cancelToken)
+                cancellationSource.Token
             );
         }
 
         public async Task PutJson<Type>(string url, Type jsonContent, CancellationToken? cancelToken = null)
         {
-            var content = JsonContent.Create(jsonContent, null, SerializerOptions);
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var content = JsonContent.Create(jsonContent, null, SerializerOptions);
             await content.LoadIntoBufferAsync(); // avoid chunked encoding
-            await HttpClient.PutAsync(
+            using var response = await HttpClient.PutAsync(
                 url,
                 content,
-                AdjustCancelToken(cancelToken)
+                cancellationSource.Token
             );
         }
 
-        private CancellationToken AdjustCancelToken(CancellationToken? cancelToken = null)
+        private CancellationTokenSource CreateRequestCancellationSource(CancellationToken? cancelToken = null)
         {
-            return CancellationTokenSource.CreateLinkedTokenSource(
-                cancelToken ?? CancellationToken.None,
-                new CancellationTokenSource(TimeSpan.FromSeconds(Timeout)).Token
-            ).Token;
+            var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(cancelToken ?? CancellationToken.None);
+            cancellationSource.CancelAfter(TimeSpan.FromSeconds(Timeout));
+            return cancellationSource;
         }
 
         public async Task<bool> Exist(string url, CancellationToken? cancelToken = null)
         {
-            var requestMessage = new HttpRequestMessage(new HttpMethod("HEAD"), url);
-            var res = await HttpClient.SendAsync(requestMessage, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var requestMessage = new HttpRequestMessage(new HttpMethod("HEAD"), url);
+            using var res = await HttpClient.SendAsync(requestMessage, cancellationSource.Token);
             return EnsureExist(res);
         }
 
         public async Task<bool> DirectoryExist(string url, CancellationToken? cancelToken = null)
         {
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
             AdjustDirectoryUrl(ref url);
-            var requestMessage = new HttpRequestMessage(new HttpMethod("PROPFIND"), url);
+            using var requestMessage = new HttpRequestMessage(new HttpMethod("PROPFIND"), url);
             requestMessage.Headers.Add("Depth", "1");
-            var res = await HttpClient.SendAsync(requestMessage, AdjustCancelToken(cancelToken));
+            using var res = await HttpClient.SendAsync(requestMessage, cancellationSource.Token);
             return EnsureExist(res);
         }
 
@@ -196,34 +206,30 @@ namespace SyncClipboard.Core.Utilities.Web
 
         public async Task CreateDirectory(string url, CancellationToken? cancelToken = null)
         {
-            var requestMessage = new HttpRequestMessage(new HttpMethod("MKCOL"), url);
-            var res = await HttpClient.SendAsync(requestMessage, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var requestMessage = new HttpRequestMessage(new HttpMethod("MKCOL"), url);
+            using var res = await HttpClient.SendAsync(requestMessage, cancellationSource.Token);
             res.EnsureSuccessStatusCode();
         }
 
         public async Task Test(CancellationToken? cancelToken = null)
         {
-            HttpRequestMessage requestMessage = new()
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using HttpRequestMessage requestMessage = new()
             {
                 Method = new HttpMethod("PROPFIND")
             };
             requestMessage.Headers.Add("Depth", "1");
 
-            var res = await HttpClient.SendAsync(requestMessage, AdjustCancelToken(cancelToken));
+            using var res = await HttpClient.SendAsync(requestMessage, cancellationSource.Token);
             res.EnsureSuccessStatusCode();
         }
 
         public async Task<bool> TestAlive(CancellationToken? cancelToken = null)
         {
-            HttpRequestMessage requestMessage = new()
-            {
-                Method = new HttpMethod("PROPFIND")
-            };
-            requestMessage.Headers.Add("Depth", "1");
-
             try
             {
-                await Test();
+                await Test(cancelToken);
                 return true;
             }
             catch (Exception ex)
@@ -235,14 +241,16 @@ namespace SyncClipboard.Core.Utilities.Web
 
         public async Task Delete(string url, CancellationToken? cancelToken = null)
         {
-            var res = await HttpClient.DeleteAsync(url, AdjustCancelToken(cancelToken));
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var res = await HttpClient.DeleteAsync(url, cancellationSource.Token);
             res.EnsureSuccessStatusCode();
         }
 
         public async Task DirectoryDelete(string url, CancellationToken? cancelToken = null)
         {
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
             AdjustDirectoryUrl(ref url);
-            var res = await HttpClient.DeleteAsync(url, AdjustCancelToken(cancelToken));
+            using var res = await HttpClient.DeleteAsync(url, cancellationSource.Token);
             res.EnsureSuccessStatusCode();
         }
 
@@ -256,10 +264,11 @@ namespace SyncClipboard.Core.Utilities.Web
 
         public async Task<List<WebDavNode>> GetFolderSubList(string url, CancellationToken? cancelToken = null)
         {
-            var token = AdjustCancelToken(cancelToken);
-            var requestMessage = new HttpRequestMessage(new HttpMethod("PROPFIND"), url);
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            var token = cancellationSource.Token;
+            using var requestMessage = new HttpRequestMessage(new HttpMethod("PROPFIND"), url);
             requestMessage.Headers.Add("Depth", "1");
-            var res = await HttpClient.SendAsync(requestMessage, token);
+            using var res = await HttpClient.SendAsync(requestMessage, token);
             res.EnsureSuccessStatusCode();
 
             List<WebDavNode> list = [];

--- a/src/SyncClipboard.Desktop/ClipboardAva/ClipboardFactory.cs
+++ b/src/SyncClipboard.Desktop/ClipboardAva/ClipboardFactory.cs
@@ -21,8 +21,6 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
     private readonly MultiSourceClipboardReader Clipboard;
 
     private const string LOG_TAG = nameof(ClipboardFactory);
-    public static readonly SemaphoreSlim _semaphoreSlim = new(1, 1);
-
     public ClipboardFactory(IServiceProvider serviceProvider)
     {
         ServiceProvider = serviceProvider;
@@ -36,7 +34,7 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
 
         for (int i = 0; i < MAX_RETRY_TIMES; i++)
         {
-            await _semaphoreSlim.WaitAsync(ctk);
+            await NativeClipboardAccess.Semaphore.WaitAsync(ctk);
             try
             {
                 if (OperatingSystem.IsWindows())
@@ -69,7 +67,7 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
             {
                 await Logger.WriteAsync(ex.Message);
             }
-            finally { _semaphoreSlim.Release(); }
+            finally { NativeClipboardAccess.Semaphore.Release(); }
             await Task.Delay(200, ctk);
         }
 

--- a/src/SyncClipboard.Desktop/ClipboardAva/ClipboardSetterBase.cs
+++ b/src/SyncClipboard.Desktop/ClipboardAva/ClipboardSetterBase.cs
@@ -21,7 +21,7 @@ internal abstract class ClipboardSetterBase<ProfileType> : IClipboardSetter<Prof
             SetTimeStamp(transfer);
         }
 
-        await ClipboardFactory._semaphoreSlim.WaitAsync(ctk);
+        await NativeClipboardAccess.Semaphore.WaitAsync(ctk);
         try
         {
             await App.Current.Clipboard.SetDataAsync(transfer).WaitAsync(ctk);
@@ -29,7 +29,7 @@ internal abstract class ClipboardSetterBase<ProfileType> : IClipboardSetter<Prof
         catch { }
         finally
         {
-            ClipboardFactory._semaphoreSlim.Release();
+            NativeClipboardAccess.Semaphore.Release();
         }
 
         App.Current.Services.GetRequiredService<ClipboardListener>().TriggerClipboardChangedEvent();

--- a/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
+++ b/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
@@ -1,0 +1,79 @@
+using SyncClipboard.Core.Clipboard;
+using SyncClipboard.Core.Interfaces;
+using SyncClipboard.Core.Models;
+using SyncClipboard.Shared.Profiles;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class ClipboardChangingListenerBaseTest
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task RapidNotificationsAreDeferredAndCoalesced()
+    {
+        var factory = new TestClipboardFactory();
+        using var listener = new TestClipboardListener(factory);
+        TaskCompletionSource changed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        int changedCount = 0;
+        listener.Changed += (_, _) =>
+        {
+            Interlocked.Increment(ref changedCount);
+            changed.TrySetResult();
+        };
+
+        listener.Trigger();
+        listener.Trigger();
+        listener.Trigger();
+
+        Assert.AreEqual(0, factory.GetMetaInfomationCallCount, "Clipboard reading must not run inline in the native change callback.");
+
+        await changed.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+        await Task.Delay(100, TestContext.CancellationTokenSource.Token);
+
+        Assert.AreEqual(1, factory.GetMetaInfomationCallCount);
+        Assert.AreEqual(1, changedCount);
+    }
+
+    private sealed class TestClipboardListener(IClipboardFactory clipboardFactory) : ClipboardChangingListenerBase
+    {
+        private MetaChanged? _action;
+
+        protected override IClipboardFactory ClipboardFactory { get; } = clipboardFactory;
+
+        protected override void RegistSystemEvent(MetaChanged action) => _action = action;
+
+        protected override void UnRegistSystemEvent(MetaChanged action) => _action = null;
+
+        public void Trigger() => _action?.Invoke(null);
+    }
+
+    private sealed class TestClipboardFactory : IClipboardFactory
+    {
+        private int _getMetaInfomationCallCount;
+
+        public int GetMetaInfomationCallCount => Volatile.Read(ref _getMetaInfomationCallCount);
+
+        public Task<ClipboardMetaInfomation> GetMetaInfomation(CancellationToken ctk)
+        {
+            ctk.ThrowIfCancellationRequested();
+            Interlocked.Increment(ref _getMetaInfomationCallCount);
+            return Task.FromResult(new ClipboardMetaInfomation { Text = "test" });
+        }
+
+        public Task<Profile> CreateProfileFromMeta(ClipboardMetaInfomation metaInfomation, CancellationToken ctk)
+        {
+            ctk.ThrowIfCancellationRequested();
+            return Task.FromResult<Profile>(new TextProfile(metaInfomation.Text ?? string.Empty));
+        }
+
+        public Task<Profile> CreateProfileFromMeta(ClipboardMetaInfomation metaInfomation, bool contentControl, CancellationToken ctk)
+            => CreateProfileFromMeta(metaInfomation, ctk);
+
+        public Task<Profile> CreateProfileFromLocal(CancellationToken ctk)
+            => CreateProfileFromMeta(new ClipboardMetaInfomation { Text = "test" }, ctk);
+
+        public void SetClipboardOwner(ClipboardMetaInfomation meta) { }
+    }
+}

--- a/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
+++ b/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
@@ -11,7 +11,32 @@ public class ClipboardChangingListenerBaseTest
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
-    public async Task RapidNotificationsAreDeferredAndCoalesced()
+    public async Task NotificationWaitsForLocalClipboardWriteToFinish()
+    {
+        var factory = new TestClipboardFactory();
+        using var listener = new TestClipboardListener(factory);
+        TaskCompletionSource changed = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        listener.Changed += (_, _) => changed.TrySetResult();
+
+        await LocalClipboard.Semaphore.WaitAsync(TestContext.CancellationTokenSource.Token);
+        try
+        {
+            listener.Trigger();
+            await Task.Delay(100, TestContext.CancellationTokenSource.Token);
+
+            Assert.AreEqual(0, factory.GetMetaInfomationCallCount, "Clipboard reading must wait until the local write releases the semaphore.");
+        }
+        finally
+        {
+            LocalClipboard.Semaphore.Release();
+        }
+
+        await changed.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+        Assert.AreEqual(1, factory.GetMetaInfomationCallCount);
+    }
+
+    [TestMethod]
+    public async Task RapidNotificationsAreNotCoalesced()
     {
         var factory = new TestClipboardFactory();
         using var listener = new TestClipboardListener(factory);
@@ -19,21 +44,20 @@ public class ClipboardChangingListenerBaseTest
         int changedCount = 0;
         listener.Changed += (_, _) =>
         {
-            Interlocked.Increment(ref changedCount);
-            changed.TrySetResult();
+            if (Interlocked.Increment(ref changedCount) == 3)
+            {
+                changed.TrySetResult();
+            }
         };
 
         listener.Trigger();
         listener.Trigger();
         listener.Trigger();
 
-        Assert.AreEqual(0, factory.GetMetaInfomationCallCount, "Clipboard reading must not run inline in the native change callback.");
-
         await changed.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
-        await Task.Delay(100, TestContext.CancellationTokenSource.Token);
 
-        Assert.AreEqual(1, factory.GetMetaInfomationCallCount);
-        Assert.AreEqual(1, changedCount);
+        Assert.AreEqual(3, factory.GetMetaInfomationCallCount);
+        Assert.AreEqual(3, changedCount);
     }
 
     private sealed class TestClipboardListener(IClipboardFactory clipboardFactory) : ClipboardChangingListenerBase

--- a/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
+++ b/src/SyncClipboard.Test/ClipboardChangingListenerBaseTest.cs
@@ -11,7 +11,7 @@ public class ClipboardChangingListenerBaseTest
     public TestContext TestContext { get; set; } = null!;
 
     [TestMethod]
-    public async Task NotificationWaitsForLocalClipboardWriteToFinish()
+    public async Task NotificationDoesNotWaitForBusinessLayerClipboardMutex()
     {
         var factory = new TestClipboardFactory();
         using var listener = new TestClipboardListener(factory);
@@ -22,17 +22,14 @@ public class ClipboardChangingListenerBaseTest
         try
         {
             listener.Trigger();
-            await Task.Delay(100, TestContext.CancellationTokenSource.Token);
+            await changed.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
 
-            Assert.AreEqual(0, factory.GetMetaInfomationCallCount, "Clipboard reading must wait until the local write releases the semaphore.");
+            Assert.AreEqual(1, factory.GetMetaInfomationCallCount, "Native clipboard synchronization belongs in the platform factory, not the business-layer mutex.");
         }
         finally
         {
             LocalClipboard.Semaphore.Release();
         }
-
-        await changed.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
-        Assert.AreEqual(1, factory.GetMetaInfomationCallCount);
     }
 
     [TestMethod]

--- a/src/SyncClipboard.Test/SingletonTaskTest.cs
+++ b/src/SyncClipboard.Test/SingletonTaskTest.cs
@@ -1,0 +1,42 @@
+using SyncClipboard.Core.Utilities.Runner;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class SingletonTaskTest
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task RunDisposesLinkedCancellationTokenSourceAfterCompletion()
+    {
+        CancellationToken capturedToken = default;
+        var singletonTask = new SingletonTask(token =>
+        {
+            capturedToken = token;
+            return Task.CompletedTask;
+        });
+
+        await singletonTask.Run();
+
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = capturedToken.WaitHandle);
+    }
+
+    [TestMethod]
+    public async Task CancelDoesNotFaultRunningTaskAfterSourceIsDisposed()
+    {
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        var singletonTask = new SingletonTask(async token =>
+        {
+            started.SetResult();
+            await Task.Delay(Timeout.InfiniteTimeSpan, token);
+        });
+
+        var runningTask = singletonTask.Run();
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+
+        singletonTask.Cancel();
+
+        await runningTask.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+    }
+}

--- a/src/SyncClipboard.Test/WebDavBaseTest.cs
+++ b/src/SyncClipboard.Test/WebDavBaseTest.cs
@@ -1,0 +1,103 @@
+using SyncClipboard.Core.Interfaces;
+using SyncClipboard.Core.Utilities.Web;
+using System.Net;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class WebDavBaseTest
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task RequestDisposesTimeoutCancellationSourceAfterCompletion()
+    {
+        using var handler = new RecordingHandler();
+        using var webDav = new TestWebDav(handler);
+
+        var text = await webDav.GetText("test", TestContext.CancellationTokenSource.Token);
+
+        Assert.AreEqual("ok", text);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = handler.CapturedToken.WaitHandle);
+    }
+
+    [TestMethod]
+    public async Task RequestLinksCallerCancellationToken()
+    {
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new RecordingHandler(started);
+        using var webDav = new TestWebDav(handler);
+        using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationTokenSource.Token);
+
+        var request = webDav.GetText("test", cancellationSource.Token);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+        cancellationSource.Cancel();
+
+        await Assert.ThrowsExactlyAsync<TaskCanceledException>(() => request);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = handler.CapturedToken.WaitHandle);
+    }
+
+    [TestMethod]
+    public async Task TestAliveForwardsCallerCancellationToken()
+    {
+        TaskCompletionSource started = new(TaskCreationOptions.RunContinuationsAsynchronously);
+        using var handler = new RecordingHandler(started);
+        using var webDav = new TestWebDav(handler);
+        using var cancellationSource = CancellationTokenSource.CreateLinkedTokenSource(TestContext.CancellationTokenSource.Token);
+
+        var request = webDav.TestAlive(cancellationSource.Token);
+        await started.Task.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+        cancellationSource.Cancel();
+
+        var result = await request.WaitAsync(TimeSpan.FromSeconds(2), TestContext.CancellationTokenSource.Token);
+
+        Assert.IsFalse(result);
+        Assert.ThrowsExactly<ObjectDisposedException>(() => _ = handler.CapturedToken.WaitHandle);
+    }
+
+    private sealed class RecordingHandler(TaskCompletionSource? started = null) : HttpMessageHandler
+    {
+        public CancellationToken CapturedToken { get; private set; }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            CapturedToken = cancellationToken;
+            if (started is not null)
+            {
+                started.TrySetResult();
+                await Task.Delay(Timeout.InfiniteTimeSpan, cancellationToken);
+            }
+
+            return new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("ok")
+            };
+        }
+    }
+
+    private sealed class TestWebDav(HttpMessageHandler handler) : WebDavBase
+    {
+        protected override IAppConfig AppConfig { get; } = new TestAppConfig();
+        protected override string User => "user";
+        protected override string Token => "token";
+        protected override string BaseAddress => "http://localhost/";
+        protected override bool TrustInsecureCertificate => false;
+
+        protected override HttpClient CreateHttpClient()
+        {
+            return new HttpClient(handler)
+            {
+                BaseAddress = new Uri(BaseAddress)
+            };
+        }
+    }
+
+    private sealed class TestAppConfig : IAppConfig
+    {
+        public string AppId => "test";
+        public string AppStringId => "test";
+        public string AppVersion => "1.0.0";
+        public string UpdateApiUrl => string.Empty;
+        public string UpdateUrl => string.Empty;
+    }
+}

--- a/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardFactory.cs
+++ b/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardFactory.cs
@@ -24,6 +24,9 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
     protected override IServiceProvider ServiceProvider { get; set; }
 
     private readonly IThreadDispatcher _dispatcher;
+    // SetContent/Flush can raise ContentChanged while pumping the UI dispatcher.
+    // Serialize native reads and writes so the event cannot re-enter WinRT clipboard APIs.
+    internal static readonly SemaphoreSlim ClipboardAccessSemaphore = new(1, 1);
 
     private const string LOG_TAG = nameof(ClipboardFactory);
 
@@ -161,9 +164,17 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
         _dispatcher = ServiceProvider.GetRequiredService<IThreadDispatcher>();
     }
 
-    public override Task<ClipboardMetaInfomation> GetMetaInfomation(CancellationToken ctk)
+    public override async Task<ClipboardMetaInfomation> GetMetaInfomation(CancellationToken ctk)
     {
-        return _dispatcher.RunOnMainThreadAsync(() => GetMetaInfomationCurrentThread(ctk));
+        await ClipboardAccessSemaphore.WaitAsync(ctk);
+        try
+        {
+            return await _dispatcher.RunOnMainThreadAsync(() => GetMetaInfomationCurrentThread(ctk));
+        }
+        finally
+        {
+            ClipboardAccessSemaphore.Release();
+        }
     }
 
     private async Task<ClipboardMetaInfomation> GetMetaInfomationCurrentThread(CancellationToken ctk)

--- a/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardFactory.cs
+++ b/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardFactory.cs
@@ -24,10 +24,6 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
     protected override IServiceProvider ServiceProvider { get; set; }
 
     private readonly IThreadDispatcher _dispatcher;
-    // SetContent/Flush can raise ContentChanged while pumping the UI dispatcher.
-    // Serialize native reads and writes so the event cannot re-enter WinRT clipboard APIs.
-    internal static readonly SemaphoreSlim ClipboardAccessSemaphore = new(1, 1);
-
     private const string LOG_TAG = nameof(ClipboardFactory);
 
     private delegate Task FormatHandler(DataPackageView ClipboardData, ClipboardMetaInfomation meta, CancellationToken ctk);
@@ -166,15 +162,8 @@ internal partial class ClipboardFactory : ClipboardFactoryBase
 
     public override async Task<ClipboardMetaInfomation> GetMetaInfomation(CancellationToken ctk)
     {
-        await ClipboardAccessSemaphore.WaitAsync(ctk);
-        try
-        {
-            return await _dispatcher.RunOnMainThreadAsync(() => GetMetaInfomationCurrentThread(ctk));
-        }
-        finally
-        {
-            ClipboardAccessSemaphore.Release();
-        }
+        using var nativeClipboardAccessGuard = await NativeClipboardAccess.AcquireAsync(ctk);
+        return await _dispatcher.RunOnMainThreadAsync(() => GetMetaInfomationCurrentThread(ctk));
     }
 
     private async Task<ClipboardMetaInfomation> GetMetaInfomationCurrentThread(CancellationToken ctk)

--- a/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardSetterBase.cs
+++ b/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardSetterBase.cs
@@ -14,27 +14,20 @@ internal abstract class ClipboardSetterBase<ProfileType> : IClipboardSetter<Prof
     private static async Task SetPackageToClipboard(DataPackage package, CancellationToken ctk)
     {
         ctk.ThrowIfCancellationRequested();
-        await ClipboardFactory.ClipboardAccessSemaphore.WaitAsync(ctk);
-        try
+        using var nativeClipboardAccessGuard = await NativeClipboardAccess.AcquireAsync(ctk);
+        Clipboard.SetContent(package);
+        // Clipboard.SetContent() still occupies the system clipboard after calling
+        for (int i = 0; i < 5; i++)
         {
-            Clipboard.SetContent(package);
-            // Clipboard.SetContent() still occupies the system clipboard after calling
-            for (int i = 0; i < 5; i++)
-            {
-                await Task.Delay(50, CancellationToken.None);
 #pragma warning disable CC0004 // Catch block cannot be empty
-                try
-                {
-                    Clipboard.Flush();
-                    return;
-                }
-                catch { }
-#pragma warning restore CC0004 // Catch block cannot be empty
+            await Task.Delay(50, CancellationToken.None);
+            try
+            {
+                Clipboard.Flush();
+                return;
             }
-        }
-        finally
-        {
-            ClipboardFactory.ClipboardAccessSemaphore.Release();
+            catch { }
+#pragma warning restore CC0004 // Catch block cannot be empty
         }
     }
 

--- a/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardSetterBase.cs
+++ b/src/SyncClipboard.WinUI3/ClipboardWinUI/ClipboardSetterBase.cs
@@ -14,19 +14,27 @@ internal abstract class ClipboardSetterBase<ProfileType> : IClipboardSetter<Prof
     private static async Task SetPackageToClipboard(DataPackage package, CancellationToken ctk)
     {
         ctk.ThrowIfCancellationRequested();
-        Clipboard.SetContent(package);
-        // Clipboard.SetContent() still occupies the system clipboard after calling
-        for (int i = 0; i < 5; i++)
+        await ClipboardFactory.ClipboardAccessSemaphore.WaitAsync(ctk);
+        try
         {
-            await Task.Delay(50, CancellationToken.None);
-#pragma warning disable CC0004 // Catch block cannot be empty
-            try
+            Clipboard.SetContent(package);
+            // Clipboard.SetContent() still occupies the system clipboard after calling
+            for (int i = 0; i < 5; i++)
             {
-                Clipboard.Flush();
-                return;
-            }
-            catch { }
+                await Task.Delay(50, CancellationToken.None);
+#pragma warning disable CC0004 // Catch block cannot be empty
+                try
+                {
+                    Clipboard.Flush();
+                    return;
+                }
+                catch { }
 #pragma warning restore CC0004 // Catch block cannot be empty
+            }
+        }
+        finally
+        {
+            ClipboardFactory.ClipboardAccessSemaphore.Release();
         }
     }
 

--- a/src/SyncClipboard.WinUI3/Views/TrayIconImpl.cs
+++ b/src/SyncClipboard.WinUI3/Views/TrayIconImpl.cs
@@ -98,6 +98,13 @@ internal class TrayIconImpl : TrayIconBase<BitmapImage>
 
     protected override void SetToolTip(string text)
     {
-        _trayIcon.DispatcherQueue.EnqueueAsync(() => _trayIcon.ToolTipText = text).Wait();
+        if (_trayIcon.DispatcherQueue.HasThreadAccess)
+        {
+            _trayIcon.ToolTipText = text;
+        }
+        else
+        {
+            _ = _trayIcon.DispatcherQueue.EnqueueAsync(() => _trayIcon.ToolTipText = text);
+        }
     }
 }


### PR DESCRIPTION
## 问题与明确根因

Windows 客户端在连续截图、频繁复制粘贴后可能卡死。第二次对卡死进程抓取完整 dump 后，UI 卡点已经明确：

1. UI 线程正在 `ClipboardSetterBase.SetPackageToClipboard -> Clipboard.Flush()`；`Flush()` 尚未返回时泵入了 Dispatcher 回调，进入 `ClipboardChangingListenerBase.NotifyAll -> ThreadDispatcher.RunOnMainThreadAsync -> ClipboardFactory.GetMetaInfomationCurrentThread -> IDataPackageView.AvailableFormats`。这会在同一个原生写入栈内重入 WinRT 剪贴板读取并阻塞 UI。
2. 同一 dump 还发现 90,408 个 `Linked2CancellationTokenSource`、90,475 个 CTS registration 和 180,912 个 callback node。GC root 指向 `OfficialEventDrivenServer -> TestAliveHelper -> 长生命周期 CancellationTokenSource`。`WebDavBase` 每次请求创建 linked CTS 和 timeout CTS 后只返回 token、从未释放；10 秒一次的 TestAlive 与 11.7 天运行时间的数量吻合。
3. `EasyCopyImageSerivce` 下载失败或被取消时没有稳定取消 `ProgressToastReporter`，其 500ms 计时器也可能长期存活。

## 修改

- `ClipboardChangingListenerBase` 不再使用 `SingletonTask`、延时、事件合并或业务层剪贴板锁；每个剪贴板事件都会保留。
- WinUI `ClipboardFactory` 与 `ClipboardSetterBase` 共享平台层原生访问锁：读端覆盖 `GetContent/AvailableFormats/数据读取`，写端覆盖 `SetContent/Flush`。因此 `ContentChanged` 即使在 Flush 泵消息时进入，也只能等写入完全退出后再读取。Avalonia 原本已有同层级的读写锁。
- 修正首个监听器注册顺序，确保添加首个 handler 时注册系统事件。
- `WebDavBase` 的每个请求自行持有并释放 linked timeout CTS，同时释放 request/response/content，并让 `TestAlive` 正确传递调用方取消令牌。
- 按 review 建议，`ProgressToastReporter` 在 End 时只停止 counter，不主动移除通知；`EasyCopyImageSerivce` 在成功、失败和取消路径显式清理 reporter 与 linked CTS。
- `SingletonTask` 修正自身 CTS 生命周期和取消竞态；WinUI3 托盘 tooltip 更新改为非阻塞 Dispatcher 调度。
- 增加回归测试，覆盖 listener 不依赖业务层锁、连续事件不合并、WebDAV CTS 释放/调用方取消/TestAlive 传递，以及 `SingletonTask` CTS 生命周期。

## 验证

- `dotnet format src/SyncClipboard.sln --verify-no-changes --severity info --no-restore --include <改动文件>`：通过
- `dotnet test src/SyncClipboard.Test --configuration Release --no-restore`：7/7 通过
- WinUI3 x64 自包含 Release（项目 CI 对应 MSBuild 参数）：通过

构建仍会报告项目现有的 Magick.NET 14.9.1 漏洞警告，本 PR 未修改依赖版本。

本 PR 只包含运行时修复和测试，不包含个人 fork 的版本号、更新源或打包 workflow 改动。