### PR TITLE
fix: manage Windows auto-start with Task Scheduler

### DIFF
--- a/src/SyncClipboard.Core/I18n/Strings.Designer.cs
+++ b/src/SyncClipboard.Core/I18n/Strings.Designer.cs
@@ -2212,7 +2212,16 @@ namespace SyncClipboard.Core.I18n {
                 return ResourceManager.GetString("RunAtSystemStartup", resourceCulture);
             }
         }
-        
+
+        /// <summary>
+        ///   查找类似 Run as Administrator 的本地化字符串。
+        /// </summary>
+        public static string RunAsAdminOnStartUp {
+            get {
+                return ResourceManager.GetString("RunAsAdminOnStartUp", resourceCulture);
+            }
+        }
+
         /// <summary>
         ///   查找类似 Access Key ID 的本地化字符串。
         /// </summary>

--- a/src/SyncClipboard.Core/I18n/Strings.resx
+++ b/src/SyncClipboard.Core/I18n/Strings.resx
@@ -264,6 +264,9 @@
   <data name="RunAtSystemStartup" xml:space="preserve">
     <value>Run at System Startup</value>
   </data>
+  <data name="RunAsAdminOnStartUp" xml:space="preserve">
+    <value>Run as Administrator</value>
+  </data>
   <data name="Language" xml:space="preserve">
     <value>Language</value>
   </data>

--- a/src/SyncClipboard.Core/I18n/Strings.zh-CN.resx
+++ b/src/SyncClipboard.Core/I18n/Strings.zh-CN.resx
@@ -264,6 +264,9 @@
   <data name="RunAtSystemStartup" xml:space="preserve">
     <value>开机启动</value>
   </data>
+  <data name="RunAsAdminOnStartUp" xml:space="preserve">
+    <value>以管理员权限启动</value>
+  </data>
   <data name="Language" xml:space="preserve">
     <value>语言</value>
   </data>

--- a/src/SyncClipboard.Core/Models/UserConfigs/ProgramConfig.cs
+++ b/src/SyncClipboard.Core/Models/UserConfigs/ProgramConfig.cs
@@ -11,6 +11,7 @@ public record ProgramConfig
     public string Language { get; set; } = "";
     public string Font { get; set; } = "";
     public bool HideWindowOnStartup { get; set; } = false;
+    public bool RunAsAdminOnStartUp { get; set; } = false;
     public bool DiagnoseMode { get; set; } = false;
     public bool DiagnosePageAutoRefresh { get; set; } = false;
     public string Theme { get; set; } = "";

--- a/src/SyncClipboard.Core/SyncClipboard.Core.csproj
+++ b/src/SyncClipboard.Core/SyncClipboard.Core.csproj
@@ -63,6 +63,10 @@
     <ProjectReference Include="..\SyncClipboard.Shared\SyncClipboard.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SyncClipboard.Test" />
+  </ItemGroup>
+
   <Target Name="Print Message" BeforeTargets="Build">
     <Message Text="RuntimeIdentifier $(RuntimeIdentifier)" />
   </Target>

--- a/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
+++ b/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
@@ -1,18 +1,654 @@
 using System.Diagnostics;
+using System.IO.Compression;
 using System.Runtime.Versioning;
+using System.Security.Principal;
+using System.Text;
+using System.Text.Json;
+using System.Xml.Linq;
 using Microsoft.Win32;
 using SyncClipboard.Core.Commons;
 
 namespace SyncClipboard.Core.Utilities;
 
+internal sealed record WindowsStartupTaskInfo(
+    string ExecutablePath,
+    string Arguments,
+    string WorkingDirectory,
+    int ActionCount,
+    string PrincipalUserId,
+    int PrincipalLogonType,
+    string TriggerUserId,
+    int TriggerCount,
+    int RunLevel,
+    bool Enabled,
+    bool TriggerEnabled,
+    bool DisallowStartIfOnBatteries,
+    bool StopIfGoingOnBatteries,
+    string ExecutionTimeLimit);
+
+internal sealed record WindowsStartupRegistryEntry(
+    string Value,
+    RegistryValueKind ValueKind);
+
+internal enum WindowsTaskLookupStatus
+{
+    NotFound,
+    Found,
+    Error,
+}
+
 public class StartUpHelper
 {
     private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+    private const int TaskRunLevelLeastPrivilege = 0;
+    private const int TaskRunLevelHighest = 1;
+    private const int FileNotFoundHResult = unchecked((int)0x80070002);
+    private const int PathNotFoundHResult = unchecked((int)0x80070003);
+    private const int TaskNotFoundHResult = unchecked((int)0x8004130F);
+    private static readonly XNamespace TaskXmlNamespace =
+        "http://schemas.microsoft.com/windows/2004/02/mit/task";
+    private const string WindowsStartupMigrationScript = """
+        $ErrorActionPreference = 'Stop'
+        $manifest = $ManifestJson | ConvertFrom-Json
+        $taskAttempted = $false
+        $legacyDeleteAttempted = $false
+        $registryDeleted = $false
+        $schtasks = Join-Path $env:SystemRoot 'System32\schtasks.exe'
+        $tempDirectory = Join-Path (
+            [System.IO.Path]::GetTempPath()) (
+            'SyncClipboard-startup-' + [Guid]::NewGuid().ToString('N'))
+        [System.IO.Directory]::CreateDirectory($tempDirectory) | Out-Null
+
+        function Write-TaskXml {
+            param(
+                [AllowNull()][string]$Xml,
+                [string]$FileName
+            )
+
+            if ([string]::IsNullOrEmpty($Xml)) {
+                return $null
+            }
+
+            $path = Join-Path $tempDirectory $FileName
+            [System.IO.File]::WriteAllText(
+                $path,
+                $Xml,
+                [System.Text.UTF8Encoding]::new($false))
+            return $path
+        }
+
+        function Remove-TransactionFiles {
+            try {
+                [System.IO.Directory]::Delete($tempDirectory, $true)
+            }
+            catch {
+            }
+        }
+
+        $newTaskXmlPath = Write-TaskXml $manifest.NewTaskXml 'new-task.xml'
+        $previousTaskXmlPath = Write-TaskXml $manifest.PreviousTaskXml 'previous-task.xml'
+        $legacyTaskXmlPath = Write-TaskXml $manifest.LegacyTaskXml 'legacy-task.xml'
+
+        function Invoke-TaskCommand {
+            param([string[]]$Arguments)
+
+            & $schtasks @Arguments | Out-Null
+            if ($LASTEXITCODE -ne 0) {
+                throw "schtasks $($Arguments -join ' ') failed with exit code $LASTEXITCODE"
+            }
+        }
+
+        function Test-PathEqual {
+            param([string]$First, [string]$Second)
+
+            try {
+                return [string]::Equals(
+                    [System.IO.Path]::GetFullPath($First),
+                    [System.IO.Path]::GetFullPath($Second),
+                    [System.StringComparison]::OrdinalIgnoreCase)
+            }
+            catch {
+                return $false
+            }
+        }
+
+        function Normalize-UserId {
+            param([string]$UserId)
+
+            if ($UserId.StartsWith('S-', [System.StringComparison]::OrdinalIgnoreCase)) {
+                return $UserId
+            }
+
+            try {
+                $account = [System.Security.Principal.NTAccount]::new($UserId)
+                return $account.Translate(
+                    [System.Security.Principal.SecurityIdentifier]).Value
+            }
+            catch {
+                try {
+                    $account = [System.Security.Principal.NTAccount]::new(
+                        $env:USERDOMAIN,
+                        $UserId)
+                    return $account.Translate(
+                        [System.Security.Principal.SecurityIdentifier]).Value
+                }
+                catch {
+                    return $UserId
+                }
+            }
+        }
+
+        function Assert-NewTask {
+            $scheduler = New-Object -ComObject 'Schedule.Service'
+            $scheduler.Connect()
+            $task = $scheduler.GetFolder('\').GetTask([string]$manifest.NewTaskName)
+            $definition = $task.Definition
+
+            if ($definition.Actions.Count -ne 1 -or $definition.Triggers.Count -ne 1) {
+                throw 'The startup task has an unexpected action or trigger count.'
+            }
+
+            $action = $definition.Actions.Item(1)
+            $trigger = $definition.Triggers.Item(1)
+            $principalUserId = Normalize-UserId ([string]$definition.Principal.UserId)
+            $triggerUserId = Normalize-UserId ([string]$trigger.UserId)
+
+            if ([int]$action.Type -ne 0 -or
+                -not (Test-PathEqual ([string]$action.Path) ([string]$manifest.ProgramPath)) -or
+                -not [string]::IsNullOrEmpty([string]$action.Arguments) -or
+                -not (Test-PathEqual ([string]$action.WorkingDirectory) ([string]$manifest.ProgramDirectory)) -or
+                -not [string]::Equals($principalUserId, [string]$manifest.UserId, [System.StringComparison]::OrdinalIgnoreCase) -or
+                [int]$definition.Principal.LogonType -ne 3 -or
+                [int]$definition.Principal.RunLevel -ne [int]$manifest.RunLevel -or
+                [int]$trigger.Type -ne 9 -or
+                -not [string]::Equals($triggerUserId, [string]$manifest.UserId, [System.StringComparison]::OrdinalIgnoreCase) -or
+                -not [bool]$task.Enabled -or
+                -not [bool]$trigger.Enabled -or
+                [bool]$definition.Settings.DisallowStartIfOnBatteries -or
+                [bool]$definition.Settings.StopIfGoingOnBatteries -or
+                [string]$definition.Settings.ExecutionTimeLimit -ne 'PT0S') {
+                throw 'The startup task does not match the requested definition.'
+            }
+        }
+
+        function Set-TaskSecurityDescriptor {
+            param(
+                [string]$TaskName,
+                [AllowNull()][string]$SecurityDescriptor
+            )
+
+            if ([string]::IsNullOrEmpty($SecurityDescriptor)) {
+                return
+            }
+
+            $scheduler = New-Object -ComObject 'Schedule.Service'
+            $scheduler.Connect()
+            $task = $scheduler.GetFolder('\').GetTask($TaskName)
+            $task.SetSecurityDescriptor($SecurityDescriptor, 0x10)
+        }
+
+        try {
+            if ($null -ne $newTaskXmlPath) {
+                $taskAttempted = $true
+                Invoke-TaskCommand @(
+                    '/Create',
+                    '/TN',
+                    [string]$manifest.NewTaskName,
+                    '/XML',
+                    [string]$newTaskXmlPath,
+                    '/F')
+                Set-TaskSecurityDescriptor (
+                    [string]$manifest.NewTaskName) (
+                    [string]$manifest.NewTaskSecurityDescriptor)
+                Assert-NewTask
+            }
+            elseif ([bool]$manifest.DeleteNewTask) {
+                $taskAttempted = $true
+                Invoke-TaskCommand @(
+                    '/Delete',
+                    '/TN',
+                    [string]$manifest.NewTaskName,
+                    '/F')
+            }
+
+            if ($null -ne $manifest.LegacyTaskName) {
+                $legacyDeleteAttempted = $true
+                Invoke-TaskCommand @(
+                    '/Delete',
+                    '/TN',
+                    [string]$manifest.LegacyTaskName,
+                    '/F')
+            }
+
+            if ($null -ne $manifest.RegistryValue) {
+                $registryPath = [string]$manifest.UserId + '\' + [string]$manifest.RunKeyPath
+                $key = [Microsoft.Win32.Registry]::Users.OpenSubKey(
+                    $registryPath,
+                    $true)
+                try {
+                    if ($null -ne $key) {
+                        $currentValue = [string]$key.GetValue(
+                            [string]$manifest.RegistryValueName)
+                        if ([string]::Equals(
+                            $currentValue,
+                            [string]$manifest.RegistryValue,
+                            [System.StringComparison]::Ordinal)) {
+                            $key.DeleteValue(
+                                [string]$manifest.RegistryValueName,
+                                $false)
+                            $registryDeleted = $true
+                        }
+                    }
+                }
+                finally {
+                    if ($null -ne $key) {
+                        $key.Dispose()
+                    }
+                }
+            }
+
+            Remove-TransactionFiles
+            exit 0
+        }
+        catch {
+            $transactionError = $_
+
+            if ($registryDeleted) {
+                try {
+                    $registryPath = [string]$manifest.UserId + '\' + [string]$manifest.RunKeyPath
+                    $key = [Microsoft.Win32.Registry]::Users.CreateSubKey(
+                        $registryPath)
+                    try {
+                        $key.SetValue(
+                            [string]$manifest.RegistryValueName,
+                            [string]$manifest.RegistryValue,
+                            [Microsoft.Win32.RegistryValueKind][int]$manifest.RegistryValueKind)
+                    }
+                    finally {
+                        $key.Dispose()
+                    }
+                }
+                catch {
+                }
+            }
+
+            if ($legacyDeleteAttempted -and $null -ne $legacyTaskXmlPath) {
+                try {
+                    Invoke-TaskCommand @(
+                        '/Create',
+                        '/TN',
+                        [string]$manifest.LegacyTaskName,
+                        '/XML',
+                        [string]$legacyTaskXmlPath,
+                        '/F')
+                    Set-TaskSecurityDescriptor (
+                        [string]$manifest.LegacyTaskName) (
+                        [string]$manifest.LegacyTaskSecurityDescriptor)
+                }
+                catch {
+                }
+            }
+
+            if ($taskAttempted) {
+                try {
+                    if ($null -ne $previousTaskXmlPath) {
+                        Invoke-TaskCommand @(
+                            '/Create',
+                            '/TN',
+                            [string]$manifest.NewTaskName,
+                            '/XML',
+                            [string]$previousTaskXmlPath,
+                            '/F')
+                        Set-TaskSecurityDescriptor (
+                            [string]$manifest.NewTaskName) (
+                            [string]$manifest.PreviousTaskSecurityDescriptor)
+                    }
+                    else {
+                        & $schtasks /Delete /TN ([string]$manifest.NewTaskName) /F | Out-Null
+                    }
+                }
+                catch {
+                }
+            }
+
+            Remove-TransactionFiles
+            Write-Output ([string]$transactionError)
+            exit 1
+        }
+        """;
+
+    private sealed record WindowsStartupMigrationManifest(
+        string NewTaskName,
+        string? NewTaskXml,
+        string? NewTaskSecurityDescriptor,
+        bool DeleteNewTask,
+        string? PreviousTaskXml,
+        string? PreviousTaskSecurityDescriptor,
+        string? LegacyTaskName,
+        string? LegacyTaskXml,
+        string? LegacyTaskSecurityDescriptor,
+        string? RegistryValue,
+        int? RegistryValueKind,
+        string RunKeyPath,
+        string RegistryValueName,
+        string UserId,
+        int RunLevel,
+        string ProgramPath,
+        string ProgramDirectory);
+
+    internal static string GetWindowsTaskName(string appName, string userId) => $"{appName}-{userId}";
+
+    [SupportedOSPlatform("windows")]
+    internal static string NormalizeWindowsUserId(string userId)
+    {
+        if (userId.StartsWith("S-", StringComparison.OrdinalIgnoreCase))
+        {
+            return userId;
+        }
+
+        try
+        {
+            var account = new NTAccount(userId);
+            return ((SecurityIdentifier)account.Translate(typeof(SecurityIdentifier))).Value;
+        }
+        catch
+        {
+            try
+            {
+                var account = new NTAccount(Environment.UserDomainName, userId);
+                return ((SecurityIdentifier)account.Translate(typeof(SecurityIdentifier))).Value;
+            }
+            catch
+            {
+                return userId;
+            }
+        }
+    }
+
+    internal static string BuildWindowsTaskXml(
+        string userId,
+        bool runAsAdmin,
+        string programPath,
+        string programDirectory)
+    {
+        var runLevel = runAsAdmin ? "HighestAvailable" : "LeastPrivilege";
+        var document = new XDocument(
+            new XDeclaration("1.0", "utf-8", null),
+            new XElement(TaskXmlNamespace + "Task",
+                new XAttribute("version", "1.2"),
+                runAsAdmin
+                    ? null
+                    : new XElement(TaskXmlNamespace + "RegistrationInfo",
+                        new XElement(
+                            TaskXmlNamespace + "SecurityDescriptor",
+                            BuildWindowsTaskSecurityDescriptor(userId))),
+                new XElement(TaskXmlNamespace + "Triggers",
+                    new XElement(TaskXmlNamespace + "LogonTrigger",
+                        new XElement(TaskXmlNamespace + "Enabled", true),
+                        new XElement(TaskXmlNamespace + "UserId", userId))),
+                new XElement(TaskXmlNamespace + "Principals",
+                    new XElement(TaskXmlNamespace + "Principal",
+                        new XAttribute("id", "Author"),
+                        new XElement(TaskXmlNamespace + "UserId", userId),
+                        new XElement(TaskXmlNamespace + "LogonType", "InteractiveToken"),
+                        new XElement(TaskXmlNamespace + "RunLevel", runLevel))),
+                new XElement(TaskXmlNamespace + "Settings",
+                    new XElement(TaskXmlNamespace + "DisallowStartIfOnBatteries", false),
+                    new XElement(TaskXmlNamespace + "StopIfGoingOnBatteries", false),
+                    new XElement(TaskXmlNamespace + "Enabled", true),
+                    new XElement(TaskXmlNamespace + "ExecutionTimeLimit", "PT0S")),
+                new XElement(TaskXmlNamespace + "Actions",
+                    new XAttribute("Context", "Author"),
+                    new XElement(TaskXmlNamespace + "Exec",
+                        new XElement(TaskXmlNamespace + "Command", programPath),
+                        new XElement(TaskXmlNamespace + "WorkingDirectory", programDirectory)))));
+
+        return document.ToString(SaveOptions.DisableFormatting);
+    }
+
+    internal static string BuildWindowsTaskSecurityDescriptor(string userId) =>
+        $"D:P(A;;FA;;;SY)(A;;FA;;;BA)(A;;FA;;;{userId})";
+
+    internal static bool IsExpectedWindowsTask(
+        WindowsStartupTaskInfo? task,
+        string userId,
+        bool? runAsAdmin,
+        string programPath,
+        string programDirectory)
+    {
+        if (task is null
+            || !PathsEqual(task.ExecutablePath, programPath)
+            || !string.IsNullOrEmpty(task.Arguments)
+            || !PathsEqual(task.WorkingDirectory, programDirectory)
+            || task.ActionCount != 1
+            || !string.Equals(task.PrincipalUserId, userId, StringComparison.OrdinalIgnoreCase)
+            || task.PrincipalLogonType != 3
+            || !string.Equals(task.TriggerUserId, userId, StringComparison.OrdinalIgnoreCase)
+            || task.TriggerCount != 1
+            || !task.Enabled
+            || !task.TriggerEnabled
+            || task.DisallowStartIfOnBatteries
+            || task.StopIfGoingOnBatteries
+            || task.ExecutionTimeLimit != "PT0S"
+            || task.RunLevel is not TaskRunLevelLeastPrivilege and not TaskRunLevelHighest)
+        {
+            return false;
+        }
+
+        return runAsAdmin is null
+            || task.RunLevel == (runAsAdmin.Value ? TaskRunLevelHighest : TaskRunLevelLeastPrivilege);
+    }
+
+    internal static bool NeedsWindowsStartupMigrationElevation(
+        bool runAsAdmin,
+        WindowsStartupTaskInfo? currentTask,
+        WindowsStartupTaskInfo? legacyTask)
+    {
+        return runAsAdmin
+            || currentTask?.RunLevel == TaskRunLevelHighest
+            || legacyTask?.RunLevel == TaskRunLevelHighest;
+    }
+
+    internal static bool CanAutomaticallyMigrateWindowsStartup(
+        WindowsTaskLookupStatus newTaskStatus,
+        WindowsTaskLookupStatus legacyTaskStatus,
+        bool legacyTaskIsExpectedAndUnprivileged,
+        bool registryEntryExists)
+    {
+        return newTaskStatus == WindowsTaskLookupStatus.NotFound
+            && legacyTaskStatus != WindowsTaskLookupStatus.Error
+            && (legacyTaskStatus == WindowsTaskLookupStatus.Found
+                ? legacyTaskIsExpectedAndUnprivileged
+                : registryEntryExists);
+    }
+
+    internal static bool CanCurrentWindowsUserRunAsAdmin()
+    {
+        return OperatingSystem.IsWindows()
+            && CurrentWindowsUserBelongsToAdministratorsGroup();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool CurrentWindowsUserBelongsToAdministratorsGroup()
+    {
+        try
+        {
+            using var identity = WindowsIdentity.GetCurrent();
+            return ContainsBuiltinAdministratorsSid(
+                identity.Groups?.Select(group => group.Value)
+                    ?? []);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static bool ContainsBuiltinAdministratorsSid(
+        IEnumerable<string> groupIds)
+    {
+        const string builtinAdministratorsSid = "S-1-5-32-544";
+        return groupIds.Contains(
+            builtinAdministratorsSid,
+            StringComparer.OrdinalIgnoreCase);
+    }
+
+    internal static bool IsExpectedLegacyWindowsTask(
+        WindowsStartupTaskInfo? task,
+        string userId,
+        string userName,
+        string programPath,
+        string programDirectory)
+    {
+        return task is not null
+            && PathsEqual(task.ExecutablePath, programPath)
+            && string.IsNullOrEmpty(task.Arguments)
+            && PathsEqual(task.WorkingDirectory, programDirectory)
+            && task.ActionCount == 1
+            && (string.Equals(task.PrincipalUserId, userId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(task.PrincipalUserId, userName, StringComparison.OrdinalIgnoreCase))
+            && task.PrincipalLogonType == 3
+            && (string.IsNullOrEmpty(task.TriggerUserId)
+                || string.Equals(task.TriggerUserId, userId, StringComparison.OrdinalIgnoreCase)
+                || string.Equals(task.TriggerUserId, userName, StringComparison.OrdinalIgnoreCase))
+            && task.TriggerCount == 1
+            && task.RunLevel is TaskRunLevelLeastPrivilege or TaskRunLevelHighest
+            && task.Enabled
+            && task.TriggerEnabled
+            && !task.DisallowStartIfOnBatteries
+            && !task.StopIfGoingOnBatteries
+            && task.ExecutionTimeLimit == "PT0S";
+    }
+
+    internal static string BuildElevatedPowerShellCommand(
+        string manifestJson,
+        string script)
+    {
+        var payload = CompressToBase64(manifestJson);
+        var bootstrap = $$"""
+            $payloadBytes = [Convert]::FromBase64String('{{payload}}')
+            $payloadStream = [IO.MemoryStream]::new([byte[]]$payloadBytes)
+            $gzipStream = [IO.Compression.GZipStream]::new(
+                $payloadStream,
+                [IO.Compression.CompressionMode]::Decompress)
+            $reader = [IO.StreamReader]::new(
+                $gzipStream,
+                [Text.UTF8Encoding]::new($false))
+            try {
+                $ManifestJson = $reader.ReadToEnd()
+            }
+            finally {
+                $reader.Dispose()
+                $gzipStream.Dispose()
+                $payloadStream.Dispose()
+            }
+            """;
+        return $"{bootstrap.TrimEnd()}{Environment.NewLine}{script}";
+    }
+
+    private static string CompressToBase64(string value)
+    {
+        var bytes = Encoding.UTF8.GetBytes(value);
+        using var compressedStream = new MemoryStream();
+        using (var gzipStream = new GZipStream(
+                   compressedStream,
+                   CompressionLevel.SmallestSize,
+                   leaveOpen: true))
+        {
+            gzipStream.Write(bytes);
+        }
+
+        return Convert.ToBase64String(compressedStream.ToArray());
+    }
+
+    internal static ProcessStartInfo CreateElevatedPowerShellStartInfo(string command)
+    {
+        var payload = CompressToBase64(command);
+        var bootstrap = $$"""
+            $commandBytes = [Convert]::FromBase64String('{{payload}}')
+            $commandStream = [IO.MemoryStream]::new([byte[]]$commandBytes)
+            $gzipStream = [IO.Compression.GZipStream]::new(
+                $commandStream,
+                [IO.Compression.CompressionMode]::Decompress)
+            $reader = [IO.StreamReader]::new(
+                $gzipStream,
+                [Text.UTF8Encoding]::new($false))
+            try {
+                $command = $reader.ReadToEnd()
+            }
+            finally {
+                $reader.Dispose()
+                $gzipStream.Dispose()
+                $commandStream.Dispose()
+            }
+            & ([ScriptBlock]::Create($command))
+            """;
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "powershell.exe",
+            UseShellExecute = true,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            Verb = "runas",
+        };
+
+        foreach (var argument in new[]
+                 {
+                     "-NoProfile",
+                     "-NonInteractive",
+                     "-ExecutionPolicy",
+                     "Bypass",
+                     "-EncodedCommand",
+                     Convert.ToBase64String(
+                         Encoding.Unicode.GetBytes(bootstrap)),
+                 })
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
+
+    private static bool PathsEqual(string first, string second)
+    {
+        try
+        {
+            return string.Equals(
+                Path.GetFullPath(first),
+                Path.GetFullPath(second),
+                StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    internal static ProcessStartInfo CreateSchtasksStartInfo(
+        IEnumerable<string> arguments,
+        bool elevate)
+    {
+        var startInfo = new ProcessStartInfo
+        {
+            FileName = "schtasks.exe",
+            UseShellExecute = elevate,
+            CreateNoWindow = !elevate,
+            WindowStyle = ProcessWindowStyle.Hidden,
+            Verb = elevate ? "runas" : string.Empty,
+        };
+
+        foreach (var argument in arguments)
+        {
+            startInfo.ArgumentList.Add(argument);
+        }
+
+        return startInfo;
+    }
 
     public static bool Status()
     {
         if (OperatingSystem.IsOSPlatform("windows"))
         {
+            TryMigrateLegacyWindowsStartupWithoutElevation();
             return CheckWindows();
         }
         else if (OperatingSystem.IsOSPlatform("linux"))
@@ -28,15 +664,18 @@ public class StartUpHelper
     // Single-parameter overload for binary compatibility with existing compiled callers
     public static void Set(bool enable) => Set(enable, runAsAdmin: false);
 
-    public static void Set(bool enable, bool runAsAdmin)
+    public static void Set(bool enable, bool runAsAdmin) => TrySet(enable, runAsAdmin);
+
+    public static bool TrySet(bool enable, bool runAsAdmin)
     {
         if (OperatingSystem.IsOSPlatform("windows"))
         {
-            SetWindows(enable, runAsAdmin);
+            return TrySetWindows(enable, runAsAdmin);
         }
         else if (OperatingSystem.IsOSPlatform("linux"))
         {
             SetLinux(enable);
+            return CheckLinux() == enable;
         }
         else
         {
@@ -44,26 +683,281 @@ public class StartUpHelper
         }
     }
 
-    [SupportedOSPlatform("windows")]
-    private static void SetWindows(bool enable, bool runAsAdmin)
+    public static bool TryGetRunAsAdmin(out bool runAsAdmin)
     {
-        // Clean up old HKCU\Run entry on every transition (migration from <3.2.x)
-        DeleteRegistryKey();
+        runAsAdmin = false;
+        return OperatingSystem.IsOSPlatform("windows")
+            && TryGetWindowsRunAsAdmin(out runAsAdmin);
+    }
 
-        if (enable)
+    [SupportedOSPlatform("windows")]
+    private static bool TrySetWindows(bool enable, bool runAsAdmin)
+    {
+        try
         {
-            CreateTaskViaCom(runAsAdmin);
+            if (enable
+                && runAsAdmin
+                && !CanCurrentWindowsUserRunAsAdmin())
+            {
+                return false;
+            }
+
+            var (userId, userName) = GetCurrentWindowsUser();
+            return enable
+                ? TryEnableWindowsStartup(userId, userName, runAsAdmin)
+                : TryDisableWindowsStartup(userId, userName);
         }
-        else
+        catch
         {
-            DeleteTask();
+            return false;
         }
     }
 
-    #region Task Scheduler (COM API)
+    [SupportedOSPlatform("windows")]
+    private static void TryMigrateLegacyWindowsStartupWithoutElevation()
+    {
+        try
+        {
+            var (userId, userName) = GetCurrentWindowsUser();
+            var taskName = GetWindowsTaskName(Env.SoftName, userId);
+            var newTaskStatus = GetWindowsTaskLookupStatus(taskName);
+            var legacyTaskStatus = GetWindowsTaskLookupStatus(Env.SoftName);
+            var legacyTask = legacyTaskStatus == WindowsTaskLookupStatus.Found
+                ? GetWindowsTaskInfo(Env.SoftName)
+                : null;
+            var canMigrateLegacyTask = IsLegacyTaskForCurrentUser(
+                    legacyTask,
+                    userId,
+                    userName)
+                && legacyTask!.RunLevel == TaskRunLevelLeastPrivilege;
+            var registryEntryExists = GetLegacyRegistryEntry() is not null;
+            if (!CanAutomaticallyMigrateWindowsStartup(
+                    newTaskStatus,
+                    legacyTaskStatus,
+                    canMigrateLegacyTask,
+                    registryEntryExists))
+            {
+                return;
+            }
+
+            TryEnableWindowsStartup(userId, userName, runAsAdmin: false);
+        }
+        catch
+        {
+        }
+    }
 
     [SupportedOSPlatform("windows")]
-    private static void CreateTaskViaCom(bool runAsAdmin)
+    private static bool TryEnableWindowsStartup(string userId, string userName, bool runAsAdmin)
+    {
+        var taskName = GetWindowsTaskName(Env.SoftName, userId);
+        var previousTaskStatus = GetWindowsTaskLookupStatus(taskName);
+        var previousTaskXml = previousTaskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskXml(taskName)
+            : null;
+        var previousTaskSecurityDescriptor =
+            previousTaskStatus == WindowsTaskLookupStatus.Found
+                ? GetWindowsTaskSecurityDescriptor(taskName)
+                : null;
+        var previousTask = previousTaskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskInfo(taskName)
+            : null;
+        var legacyTaskStatus = GetWindowsTaskLookupStatus(Env.SoftName);
+        var legacyTaskCandidate = legacyTaskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskInfo(Env.SoftName)
+            : null;
+        var legacyTask = IsLegacyTaskForCurrentUser(legacyTaskCandidate, userId, userName)
+            ? legacyTaskCandidate
+            : null;
+        var legacyTaskXml = legacyTask is null
+            ? null
+            : GetWindowsTaskXml(Env.SoftName);
+        var legacyTaskSecurityDescriptor = legacyTask is null
+            ? null
+            : GetWindowsTaskSecurityDescriptor(Env.SoftName);
+        var registryEntry = GetLegacyRegistryEntry();
+
+        if (previousTaskStatus == WindowsTaskLookupStatus.Error
+            || legacyTaskStatus == WindowsTaskLookupStatus.Error
+            || (previousTaskStatus == WindowsTaskLookupStatus.Found
+                && (previousTaskXml is null
+                    || previousTaskSecurityDescriptor is null))
+            || (legacyTask is not null
+                && (legacyTaskXml is null
+                    || legacyTaskSecurityDescriptor is null)))
+        {
+            return false;
+        }
+
+        if (NeedsWindowsStartupMigrationElevation(runAsAdmin, previousTask, legacyTask))
+        {
+            return TryRunElevatedWindowsStartupTransaction(
+                enable: true,
+                taskName,
+                userId,
+                runAsAdmin,
+                previousTaskXml,
+                previousTaskSecurityDescriptor,
+                legacyTask is null ? null : Env.SoftName,
+                legacyTaskXml,
+                legacyTaskSecurityDescriptor,
+                registryEntry);
+        }
+
+        if (!TryRegisterWindowsTaskWithoutElevation(taskName, userId, runAsAdmin)
+            || !IsExpectedWindowsTask(
+                GetWindowsTaskInfo(taskName),
+                userId,
+                runAsAdmin,
+                Env.ProgramPath,
+                Env.ProgramDirectory))
+        {
+            RestoreWindowsTask(taskName, previousTaskXml, previousTask);
+            return TryRunElevatedWindowsStartupTransaction(
+                enable: true,
+                taskName,
+                userId,
+                runAsAdmin,
+                previousTaskXml,
+                previousTaskSecurityDescriptor,
+                legacyTask is null ? null : Env.SoftName,
+                legacyTaskXml,
+                legacyTaskSecurityDescriptor,
+                registryEntry);
+        }
+
+        if (!TryRemoveLegacyWindowsStartup(userId, userName))
+        {
+            RestoreWindowsTask(Env.SoftName, legacyTaskXml, legacyTask);
+            RestoreLegacyRegistryEntry(registryEntry);
+            RestoreWindowsTask(taskName, previousTaskXml, previousTask);
+            return TryRunElevatedWindowsStartupTransaction(
+                enable: true,
+                taskName,
+                userId,
+                runAsAdmin,
+                previousTaskXml,
+                previousTaskSecurityDescriptor,
+                legacyTask is null ? null : Env.SoftName,
+                legacyTaskXml,
+                legacyTaskSecurityDescriptor,
+                registryEntry);
+        }
+
+        return true;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryDisableWindowsStartup(string userId, string userName)
+    {
+        var taskName = GetWindowsTaskName(Env.SoftName, userId);
+        var taskStatus = GetWindowsTaskLookupStatus(taskName);
+        var task = taskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskInfo(taskName)
+            : null;
+        var taskXml = taskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskXml(taskName)
+            : null;
+        var taskSecurityDescriptor = taskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskSecurityDescriptor(taskName)
+            : null;
+        var legacyTaskStatus = GetWindowsTaskLookupStatus(Env.SoftName);
+        var legacyTaskCandidate = legacyTaskStatus == WindowsTaskLookupStatus.Found
+            ? GetWindowsTaskInfo(Env.SoftName)
+            : null;
+        var legacyTask = IsLegacyTaskForCurrentUser(legacyTaskCandidate, userId, userName)
+            ? legacyTaskCandidate
+            : null;
+        var legacyTaskXml = legacyTask is null
+            ? null
+            : GetWindowsTaskXml(Env.SoftName);
+        var legacyTaskSecurityDescriptor = legacyTask is null
+            ? null
+            : GetWindowsTaskSecurityDescriptor(Env.SoftName);
+        var registryEntry = GetLegacyRegistryEntry();
+
+        if (taskStatus == WindowsTaskLookupStatus.Error
+            || legacyTaskStatus == WindowsTaskLookupStatus.Error
+            || (taskStatus == WindowsTaskLookupStatus.Found
+                && (taskXml is null
+                    || taskSecurityDescriptor is null))
+            || (legacyTask is not null
+                && (legacyTaskXml is null
+                    || legacyTaskSecurityDescriptor is null)))
+        {
+            return false;
+        }
+
+        if (NeedsWindowsStartupMigrationElevation(
+            runAsAdmin: false,
+            currentTask: task,
+            legacyTask))
+        {
+            return TryRunElevatedWindowsStartupTransaction(
+                    enable: false,
+                    taskName,
+                    userId,
+                    runAsAdmin: false,
+                    taskXml,
+                    taskSecurityDescriptor,
+                    legacyTask is null ? null : Env.SoftName,
+                    legacyTaskXml,
+                    legacyTaskSecurityDescriptor,
+                    registryEntry)
+                && !CheckWindows();
+        }
+
+        var removed = (taskStatus == WindowsTaskLookupStatus.NotFound
+                || TryDeleteWindowsTask(taskName, allowElevation: false))
+            && (legacyTask is null
+                || TryDeleteWindowsTask(Env.SoftName, allowElevation: false))
+            && TryDeleteLegacyRegistryEntry()
+            && !CheckWindows();
+        if (removed)
+        {
+            return true;
+        }
+
+        RestoreLegacyRegistryEntry(registryEntry);
+        RestoreWindowsTask(Env.SoftName, legacyTaskXml, legacyTask);
+        RestoreWindowsTask(taskName, taskXml, task);
+        return TryRunElevatedWindowsStartupTransaction(
+                enable: false,
+                taskName,
+                userId,
+                runAsAdmin: false,
+                taskXml,
+                taskSecurityDescriptor,
+                legacyTask is null ? null : Env.SoftName,
+                legacyTaskXml,
+                legacyTaskSecurityDescriptor,
+                registryEntry)
+            && !CheckWindows();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryRegisterWindowsTaskWithoutElevation(
+        string taskName,
+        string userId,
+        bool runAsAdmin)
+    {
+        if (TryCreateTaskViaCom(taskName, userId, runAsAdmin)
+            && IsExpectedWindowsTask(
+                GetWindowsTaskInfo(taskName),
+                userId,
+                runAsAdmin,
+                Env.ProgramPath,
+                Env.ProgramDirectory))
+        {
+            return true;
+        }
+
+        var xml = BuildWindowsTaskXml(userId, runAsAdmin, Env.ProgramPath, Env.ProgramDirectory);
+        return TryRegisterTaskXml(taskName, xml, elevate: false);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryCreateTaskViaCom(string taskName, string userId, bool runAsAdmin)
     {
         try
         {
@@ -73,103 +967,504 @@ public class StartUpHelper
             dynamic folder = scheduler.GetFolder("\\");
             dynamic taskDef = scheduler.NewTask(0);
 
-            taskDef.Principal.RunLevel = runAsAdmin ? 1 : 0; // 1=Highest, 0=LUA
+            taskDef.Principal.UserId = userId;
+            taskDef.Principal.LogonType = 3; // TASK_LOGON_INTERACTIVE_TOKEN
+            taskDef.Principal.RunLevel = runAsAdmin
+                ? TaskRunLevelHighest
+                : TaskRunLevelLeastPrivilege;
             taskDef.Settings.DisallowStartIfOnBatteries = false;
             taskDef.Settings.StopIfGoingOnBatteries = false;
-            taskDef.Settings.ExecutionTimeLimit = "PT0S"; // disable 72h default limit
-            taskDef.Triggers.Create(9); // TASK_TRIGGER_LOGON
+            taskDef.Settings.ExecutionTimeLimit = "PT0S";
+            taskDef.Settings.Enabled = true;
+
+            dynamic trigger = taskDef.Triggers.Create(9); // TASK_TRIGGER_LOGON
+            trigger.Enabled = true;
+            trigger.UserId = userId;
 
             dynamic action = taskDef.Actions.Create(0); // TASK_ACTION_EXEC
             action.Path = Env.ProgramPath;
             action.WorkingDirectory = Env.ProgramDirectory;
 
             // 6 = TASK_CREATE_OR_UPDATE, 3 = TASK_LOGON_INTERACTIVE_TOKEN
-            folder.RegisterTaskDefinition(Env.SoftName, taskDef, 6, null, null, 3, null);
+            folder.RegisterTaskDefinition(taskName, taskDef, 6, userId, null, 3, null);
+            return true;
         }
         catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryRegisterTaskXml(string taskName, string xml, bool elevate)
+    {
+        var xmlPath = Path.Combine(Path.GetTempPath(), $"{Guid.NewGuid():N}.xml");
+        try
+        {
+            WriteTaskXml(xmlPath, xml);
+            return RunSchtasks(
+                ["/Create", "/TN", taskName, "/XML", xmlPath, "/F"],
+                elevate);
+        }
+        catch
+        {
+            return false;
+        }
+        finally
         {
             try
             {
-                var rl = runAsAdmin ? "/rl highest" : "";
-                var psi = new ProcessStartInfo
-                {
-                    FileName = "schtasks",
-                    Arguments = $"/create /tn \"{Env.SoftName}\" /tr \"\\\"{Env.ProgramPath}\\\"\" /sc onlogon {rl} /f",
-                    UseShellExecute = false,
-                    CreateNoWindow = true,
-                };
-                Process.Start(psi)?.WaitForExit();
+                File.Delete(xmlPath);
             }
             catch
             {
-                // Both methods failed — give up silently
+                // The temporary file is best-effort cleanup after registration.
             }
         }
     }
 
     [SupportedOSPlatform("windows")]
-    private static void DeleteTask()
+    private static bool TryRunElevatedWindowsStartupTransaction(
+        bool enable,
+        string taskName,
+        string userId,
+        bool runAsAdmin,
+        string? previousTaskXml,
+        string? previousTaskSecurityDescriptor,
+        string? legacyTaskName,
+        string? legacyTaskXml,
+        string? legacyTaskSecurityDescriptor,
+        WindowsStartupRegistryEntry? registryEntry)
     {
         try
         {
-            var psi = new ProcessStartInfo
+            var newTaskXml = enable
+                ? NormalizeTaskXml(
+                    BuildWindowsTaskXml(
+                        userId,
+                        runAsAdmin,
+                        Env.ProgramPath,
+                        Env.ProgramDirectory))
+                : null;
+
+            var manifest = new WindowsStartupMigrationManifest(
+                taskName,
+                newTaskXml,
+                enable && !runAsAdmin
+                    ? BuildWindowsTaskSecurityDescriptor(userId)
+                    : null,
+                DeleteNewTask: !enable && previousTaskXml is not null,
+                previousTaskXml is null ? null : NormalizeTaskXml(previousTaskXml),
+                previousTaskSecurityDescriptor,
+                legacyTaskName,
+                legacyTaskXml is null ? null : NormalizeTaskXml(legacyTaskXml),
+                legacyTaskSecurityDescriptor,
+                registryEntry?.Value,
+                registryEntry is null ? null : (int)registryEntry.ValueKind,
+                RunKeyPath,
+                Env.SoftName,
+                userId,
+                runAsAdmin ? TaskRunLevelHighest : TaskRunLevelLeastPrivilege,
+                Env.ProgramPath,
+                Env.ProgramDirectory);
+            var command = BuildElevatedPowerShellCommand(
+                JsonSerializer.Serialize(manifest),
+                WindowsStartupMigrationScript);
+            var startInfo = CreateElevatedPowerShellStartInfo(command);
+            if (startInfo.ArgumentList[^1].Length >= 30_000)
             {
-                FileName = "schtasks",
-                Arguments = $"/delete /tn \"{Env.SoftName}\" /f",
-                UseShellExecute = false,
-                CreateNoWindow = true,
-            };
-            Process.Start(psi)?.WaitForExit();
+                return false;
+            }
+
+            using var process = Process.Start(startInfo);
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+            return process.ExitCode == 0;
         }
         catch
         {
-            // Task may not exist
+            return false;
         }
     }
 
-    #endregion
+    private static void WriteTaskXml(string path, string xml)
+    {
+        File.WriteAllText(
+            path,
+            NormalizeTaskXml(xml),
+            new UTF8Encoding(encoderShouldEmitUTF8Identifier: false));
+    }
 
-    #region Registry (HKCU\Run) — migration cleanup
+    private static string NormalizeTaskXml(string xml)
+    {
+        var document = XDocument.Parse(xml);
+        document.Declaration = new XDeclaration("1.0", "utf-8", null);
+        return document.ToString(SaveOptions.DisableFormatting);
+    }
 
     [SupportedOSPlatform("windows")]
-    private static void DeleteRegistryKey()
+    private static bool TryDeleteWindowsTask(string taskName, bool allowElevation)
+    {
+        var taskStatus = GetWindowsTaskLookupStatus(taskName);
+        if (taskStatus == WindowsTaskLookupStatus.NotFound)
+        {
+            return true;
+        }
+
+        if (taskStatus == WindowsTaskLookupStatus.Error)
+        {
+            return false;
+        }
+
+        var arguments = new[] { "/Delete", "/TN", taskName, "/F" };
+        if (RunSchtasks(arguments, elevate: false)
+            && GetWindowsTaskLookupStatus(taskName) == WindowsTaskLookupStatus.NotFound)
+        {
+            return true;
+        }
+
+        return allowElevation
+            && RunSchtasks(arguments, elevate: true)
+            && GetWindowsTaskLookupStatus(taskName) == WindowsTaskLookupStatus.NotFound;
+    }
+
+    private static bool RunSchtasks(IEnumerable<string> arguments, bool elevate)
     {
         try
         {
-            Registry.CurrentUser.OpenSubKey(RunKeyPath, true)?.DeleteValue(Env.SoftName, false);
+            using var process = Process.Start(CreateSchtasksStartInfo(arguments, elevate));
+            if (process is null)
+            {
+                return false;
+            }
+
+            process.WaitForExit();
+            return process.ExitCode == 0;
         }
         catch
         {
-            // Key may not exist
+            return false;
         }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static WindowsTaskLookupStatus GetWindowsTaskLookupStatus(string taskName)
+    {
+        try
+        {
+            var schedulerType = Type.GetTypeFromProgID("Schedule.Service", true)!;
+            dynamic scheduler = Activator.CreateInstance(schedulerType)!;
+            scheduler.Connect();
+            scheduler.GetFolder("\\").GetTask(taskName);
+            return WindowsTaskLookupStatus.Found;
+        }
+        catch (Exception exception)
+            when (exception.HResult is
+                FileNotFoundHResult or PathNotFoundHResult or TaskNotFoundHResult)
+        {
+            return WindowsTaskLookupStatus.NotFound;
+        }
+        catch
+        {
+            return WindowsTaskLookupStatus.Error;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static WindowsStartupTaskInfo? GetWindowsTaskInfo(string taskName)
+    {
+        try
+        {
+            var schedulerType = Type.GetTypeFromProgID("Schedule.Service", true)!;
+            dynamic scheduler = Activator.CreateInstance(schedulerType)!;
+            scheduler.Connect();
+            dynamic task = scheduler.GetFolder("\\").GetTask(taskName);
+            dynamic definition = task.Definition;
+
+            dynamic? execAction = null;
+            for (var index = 1; index <= definition.Actions.Count; index++)
+            {
+                dynamic candidate = definition.Actions.Item(index);
+                if (Convert.ToInt32(candidate.Type) == 0) // TASK_ACTION_EXEC
+                {
+                    execAction = candidate;
+                    break;
+                }
+            }
+
+            dynamic? logonTrigger = null;
+            for (var index = 1; index <= definition.Triggers.Count; index++)
+            {
+                dynamic candidate = definition.Triggers.Item(index);
+                if (Convert.ToInt32(candidate.Type) == 9) // TASK_TRIGGER_LOGON
+                {
+                    logonTrigger = candidate;
+                    break;
+                }
+            }
+
+            if (execAction is null || logonTrigger is null)
+            {
+                return null;
+            }
+
+            return new WindowsStartupTaskInfo(
+                Convert.ToString(execAction.Path) ?? string.Empty,
+                Convert.ToString(execAction.Arguments) ?? string.Empty,
+                Convert.ToString(execAction.WorkingDirectory) ?? string.Empty,
+                Convert.ToInt32(definition.Actions.Count),
+                NormalizeWindowsUserId(
+                    Convert.ToString(definition.Principal.UserId) ?? string.Empty),
+                Convert.ToInt32(definition.Principal.LogonType),
+                NormalizeWindowsUserId(
+                    Convert.ToString(logonTrigger.UserId) ?? string.Empty),
+                Convert.ToInt32(definition.Triggers.Count),
+                Convert.ToInt32(definition.Principal.RunLevel),
+                Convert.ToBoolean(task.Enabled),
+                Convert.ToBoolean(logonTrigger.Enabled),
+                Convert.ToBoolean(definition.Settings.DisallowStartIfOnBatteries),
+                Convert.ToBoolean(definition.Settings.StopIfGoingOnBatteries),
+                Convert.ToString(definition.Settings.ExecutionTimeLimit) ?? string.Empty);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? GetWindowsTaskSecurityDescriptor(string taskName)
+    {
+        try
+        {
+            var schedulerType = Type.GetTypeFromProgID("Schedule.Service", true)!;
+            dynamic scheduler = Activator.CreateInstance(schedulerType)!;
+            scheduler.Connect();
+            dynamic task = scheduler.GetFolder("\\").GetTask(taskName);
+            const int daclSecurityInformation = 0x4;
+            return Convert.ToString(
+                task.GetSecurityDescriptor(daclSecurityInformation));
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static string? GetWindowsTaskXml(string taskName)
+    {
+        try
+        {
+            var schedulerType = Type.GetTypeFromProgID("Schedule.Service", true)!;
+            dynamic scheduler = Activator.CreateInstance(schedulerType)!;
+            scheduler.Connect();
+            dynamic task = scheduler.GetFolder("\\").GetTask(taskName);
+            return Convert.ToString(task.Xml);
+        }
+        catch
+        {
+            return null;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RestoreWindowsTask(
+        string taskName,
+        string? previousTaskXml,
+        WindowsStartupTaskInfo? previousTask)
+    {
+        var currentTask = GetWindowsTaskInfo(taskName);
+        if (currentTask == previousTask)
+        {
+            return;
+        }
+
+        if (previousTaskXml is null)
+        {
+            if (currentTask is not null)
+            {
+                TryDeleteWindowsTask(
+                    taskName,
+                    allowElevation: currentTask.RunLevel == TaskRunLevelHighest);
+            }
+
+            return;
+        }
+
+        TryRegisterTaskXml(
+            taskName,
+            previousTaskXml,
+            elevate: previousTask?.RunLevel == TaskRunLevelHighest);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryRemoveLegacyWindowsStartup(string userId, string userName)
+    {
+        var legacyTask = GetWindowsTaskInfo(Env.SoftName);
+        if (IsLegacyTaskForCurrentUser(legacyTask, userId, userName)
+            && !TryDeleteWindowsTask(
+                Env.SoftName,
+                allowElevation: legacyTask!.RunLevel == TaskRunLevelHighest))
+        {
+            return false;
+        }
+
+        return TryDeleteLegacyRegistryEntry();
+    }
+
+    private static bool IsLegacyTaskForCurrentUser(
+        WindowsStartupTaskInfo? task,
+        string userId,
+        string userName)
+    {
+        return IsExpectedLegacyWindowsTask(
+            task,
+            userId,
+            userName,
+            Env.ProgramPath,
+            Env.ProgramDirectory);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryDeleteLegacyRegistryEntry()
+    {
+        try
+        {
+            if (GetLegacyRegistryEntry() is null)
+            {
+                return true;
+            }
+
+            using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: true);
+            key?.DeleteValue(Env.SoftName, throwOnMissingValue: false);
+            return !HasLegacyRegistryEntry();
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static WindowsStartupRegistryEntry? GetLegacyRegistryEntry()
+    {
+        using var key = Registry.CurrentUser.OpenSubKey(RunKeyPath, writable: false);
+        if (key is null
+            || key.GetValue(Env.SoftName) is not string path
+            || !PathsEqual(path, Env.ProgramPath))
+        {
+            return null;
+        }
+
+        return new WindowsStartupRegistryEntry(path, key.GetValueKind(Env.SoftName));
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RestoreLegacyRegistryEntry(WindowsStartupRegistryEntry? previousEntry)
+    {
+        if (previousEntry is null)
+        {
+            return;
+        }
+
+        try
+        {
+            using var key = Registry.CurrentUser.CreateSubKey(RunKeyPath);
+            if (key.GetValue(Env.SoftName) is null)
+            {
+                key.SetValue(Env.SoftName, previousEntry.Value, previousEntry.ValueKind);
+            }
+        }
+        catch
+        {
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool HasLegacyRegistryEntry()
+    {
+        return GetLegacyRegistryEntry() is not null;
     }
 
     [SupportedOSPlatform("windows")]
     private static bool CheckWindows()
     {
-        // Primary: Task Scheduler
-        var psi = new ProcessStartInfo
+        try
         {
-            FileName = "schtasks",
-            Arguments = $"/query /tn \"{Env.SoftName}\"",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-        var process = Process.Start(psi);
-        process?.WaitForExit();
-        if (process?.ExitCode == 0)
-        {
-            return true;
-        }
+            var (userId, userName) = GetCurrentWindowsUser();
+            var task = GetWindowsTaskInfo(GetWindowsTaskName(Env.SoftName, userId));
+            if (IsExpectedWindowsTask(
+                task,
+                userId,
+                runAsAdmin: null,
+                Env.ProgramPath,
+                Env.ProgramDirectory))
+            {
+                return true;
+            }
 
-        // Fallback: legacy HKCU\Run entry (users upgrading from <3.2.x)
-        var path = Registry.GetValue(
-            @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
-            Env.SoftName, null);
-        return path as string == Env.ProgramPath;
+            var legacyTask = GetWindowsTaskInfo(Env.SoftName);
+            return (IsLegacyTaskForCurrentUser(legacyTask, userId, userName)
+                    && legacyTask!.Enabled
+                    && legacyTask.TriggerEnabled
+                    && PathsEqual(legacyTask.WorkingDirectory, Env.ProgramDirectory))
+                || HasLegacyRegistryEntry();
+        }
+        catch
+        {
+            return false;
+        }
     }
 
-    #endregion
+    [SupportedOSPlatform("windows")]
+    private static bool TryGetWindowsRunAsAdmin(out bool runAsAdmin)
+    {
+        runAsAdmin = false;
+        try
+        {
+            var (userId, userName) = GetCurrentWindowsUser();
+            var task = GetWindowsTaskInfo(GetWindowsTaskName(Env.SoftName, userId));
+            if (IsExpectedWindowsTask(
+                task,
+                userId,
+                runAsAdmin: null,
+                Env.ProgramPath,
+                Env.ProgramDirectory))
+            {
+                runAsAdmin = task!.RunLevel == TaskRunLevelHighest;
+                return true;
+            }
+
+            var legacyTask = GetWindowsTaskInfo(Env.SoftName);
+            if (IsLegacyTaskForCurrentUser(legacyTask, userId, userName)
+                && legacyTask!.Enabled
+                && legacyTask.TriggerEnabled
+                && PathsEqual(legacyTask.WorkingDirectory, Env.ProgramDirectory))
+            {
+                runAsAdmin = legacyTask.RunLevel == TaskRunLevelHighest;
+                return true;
+            }
+        }
+        catch
+        {
+        }
+
+        return false;
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static (string UserId, string UserName) GetCurrentWindowsUser()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        var userId = identity.User?.Value
+            ?? throw new InvalidOperationException("The current Windows user does not have a SID.");
+        return (userId, identity.Name);
+    }
 
     #region Linux
 

--- a/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
+++ b/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
@@ -1,7 +1,5 @@
-﻿using System.Diagnostics;
+using System.Diagnostics;
 using System.Runtime.Versioning;
-using System.Security.Principal;
-using Microsoft.Win32;
 using SyncClipboard.Core.Commons;
 
 namespace SyncClipboard.Core.Utilities;
@@ -24,11 +22,11 @@ public class StartUpHelper
         }
     }
 
-    public static void Set(bool enable)
+    public static void Set(bool enable, bool runAsAdmin = false)
     {
         if (OperatingSystem.IsOSPlatform("windows"))
         {
-            SetWindows(enable);
+            SetWindows(enable, runAsAdmin);
         }
         else if (OperatingSystem.IsOSPlatform("linux"))
         {
@@ -41,39 +39,20 @@ public class StartUpHelper
     }
 
     [SupportedOSPlatform("windows")]
-    private static bool IsElevated()
-    {
-        using var identity = WindowsIdentity.GetCurrent();
-        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
-    }
-
-    [SupportedOSPlatform("windows")]
-    private static void SetWindows(bool enable)
+    private static void SetWindows(bool enable, bool runAsAdmin)
     {
         if (enable)
         {
-            if (IsElevated())
-            {
-                // Running elevated: must use Task Scheduler — HKCU\Run is blocked by UAC
-                CreateTaskViaCom();
-                CleanupRegistryKey();
-            }
-            else
-            {
-                // Running normally: use registry — schtasks /rl highest would fail without elevation
-                SetRegistry(true);
-                DeleteTask();
-            }
+            CreateTaskViaCom(runAsAdmin);
         }
         else
         {
-            SetRegistry(false);
             DeleteTask();
         }
     }
 
     [SupportedOSPlatform("windows")]
-    private static void CreateTaskViaCom()
+    private static void CreateTaskViaCom(bool runAsAdmin)
     {
         try
         {
@@ -83,7 +62,7 @@ public class StartUpHelper
             dynamic folder = scheduler.GetFolder("\\");
             dynamic taskDef = scheduler.NewTask(0);
 
-            taskDef.Principal.RunLevel = 1; // TASK_RUNLEVEL_HIGHEST
+            taskDef.Principal.RunLevel = runAsAdmin ? 1 : 0; // 1 = TASK_RUNLEVEL_HIGHEST, 0 = TASK_RUNLEVEL_LUA
             taskDef.Settings.DisallowStartIfOnBatteries = false;
             taskDef.Settings.StopIfGoingOnBatteries = false;
             taskDef.Triggers.Create(9); // TASK_TRIGGER_LOGON
@@ -100,10 +79,11 @@ public class StartUpHelper
             // Fallback: schtasks CLI (no WorkingDirectory — may fail for WinUI3/self-contained apps)
             try
             {
+                var rl = runAsAdmin ? "/rl highest" : "";
                 var psi = new ProcessStartInfo
                 {
                     FileName = "schtasks",
-                    Arguments = $"/create /tn \"{Env.SoftName}\" /tr \"\\\"{Env.ProgramPath}\\\"\" /sc onlogon /rl highest /f",
+                    Arguments = $"/create /tn \"{Env.SoftName}\" /tr \"\\\"{Env.ProgramPath}\\\"\" /sc onlogon {rl} /f",
                     UseShellExecute = false,
                     CreateNoWindow = true,
                 };
@@ -136,38 +116,6 @@ public class StartUpHelper
         }
     }
 
-    [SupportedOSPlatform("windows")]
-    private static void SetRegistry(bool enable)
-    {
-        if (enable)
-        {
-            Registry.SetValue(
-                @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
-                Env.SoftName, Env.ProgramPath);
-        }
-        else
-        {
-            Registry.CurrentUser.OpenSubKey(
-                @"Software\Microsoft\Windows\CurrentVersion\Run", true)
-                ?.DeleteValue(Env.SoftName, false);
-        }
-    }
-
-    [SupportedOSPlatform("windows")]
-    private static void CleanupRegistryKey()
-    {
-        try
-        {
-            Registry.CurrentUser.OpenSubKey(
-                @"Software\Microsoft\Windows\CurrentVersion\Run", true)
-                ?.DeleteValue(Env.SoftName, false);
-        }
-        catch
-        {
-            // Key may not exist
-        }
-    }
-
     [SupportedOSPlatform("linux")]
     private static void SetLinux(bool enable)
     {
@@ -190,7 +138,6 @@ public class StartUpHelper
     [SupportedOSPlatform("windows")]
     private static bool CheckWindows()
     {
-        // Check task scheduler first
         var psi = new ProcessStartInfo
         {
             FileName = "schtasks",
@@ -200,16 +147,7 @@ public class StartUpHelper
         };
         var process = Process.Start(psi);
         process?.WaitForExit();
-        if (process?.ExitCode == 0)
-        {
-            return true;
-        }
-
-        // Fallback: check old registry method
-        var path = Registry.GetValue(
-            @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
-            Env.SoftName, null);
-        return path as string == Env.ProgramPath;
+        return process?.ExitCode == 0;
     }
 
     [SupportedOSPlatform("linux")]

--- a/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
+++ b/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
@@ -1,11 +1,14 @@
 using System.Diagnostics;
 using System.Runtime.Versioning;
+using Microsoft.Win32;
 using SyncClipboard.Core.Commons;
 
 namespace SyncClipboard.Core.Utilities;
 
 public class StartUpHelper
 {
+    private const string RunKeyPath = @"Software\Microsoft\Windows\CurrentVersion\Run";
+
     public static bool Status()
     {
         if (OperatingSystem.IsOSPlatform("windows"))
@@ -22,7 +25,10 @@ public class StartUpHelper
         }
     }
 
-    public static void Set(bool enable, bool runAsAdmin = false)
+    // Single-parameter overload for binary compatibility with existing compiled callers
+    public static void Set(bool enable) => Set(enable, runAsAdmin: false);
+
+    public static void Set(bool enable, bool runAsAdmin)
     {
         if (OperatingSystem.IsOSPlatform("windows"))
         {
@@ -41,6 +47,9 @@ public class StartUpHelper
     [SupportedOSPlatform("windows")]
     private static void SetWindows(bool enable, bool runAsAdmin)
     {
+        // Clean up old HKCU\Run entry on every transition (migration from <3.2.x)
+        DeleteRegistryKey();
+
         if (enable)
         {
             CreateTaskViaCom(runAsAdmin);
@@ -50,6 +59,8 @@ public class StartUpHelper
             DeleteTask();
         }
     }
+
+    #region Task Scheduler (COM API)
 
     [SupportedOSPlatform("windows")]
     private static void CreateTaskViaCom(bool runAsAdmin)
@@ -62,9 +73,10 @@ public class StartUpHelper
             dynamic folder = scheduler.GetFolder("\\");
             dynamic taskDef = scheduler.NewTask(0);
 
-            taskDef.Principal.RunLevel = runAsAdmin ? 1 : 0; // 1 = TASK_RUNLEVEL_HIGHEST, 0 = TASK_RUNLEVEL_LUA
+            taskDef.Principal.RunLevel = runAsAdmin ? 1 : 0; // 1=Highest, 0=LUA
             taskDef.Settings.DisallowStartIfOnBatteries = false;
             taskDef.Settings.StopIfGoingOnBatteries = false;
+            taskDef.Settings.ExecutionTimeLimit = "PT0S"; // disable 72h default limit
             taskDef.Triggers.Create(9); // TASK_TRIGGER_LOGON
 
             dynamic action = taskDef.Actions.Create(0); // TASK_ACTION_EXEC
@@ -76,7 +88,6 @@ public class StartUpHelper
         }
         catch
         {
-            // Fallback: schtasks CLI (no WorkingDirectory — may fail for WinUI3/self-contained apps)
             try
             {
                 var rl = runAsAdmin ? "/rl highest" : "";
@@ -116,6 +127,52 @@ public class StartUpHelper
         }
     }
 
+    #endregion
+
+    #region Registry (HKCU\Run) — migration cleanup
+
+    [SupportedOSPlatform("windows")]
+    private static void DeleteRegistryKey()
+    {
+        try
+        {
+            Registry.CurrentUser.OpenSubKey(RunKeyPath, true)?.DeleteValue(Env.SoftName, false);
+        }
+        catch
+        {
+            // Key may not exist
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool CheckWindows()
+    {
+        // Primary: Task Scheduler
+        var psi = new ProcessStartInfo
+        {
+            FileName = "schtasks",
+            Arguments = $"/query /tn \"{Env.SoftName}\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var process = Process.Start(psi);
+        process?.WaitForExit();
+        if (process?.ExitCode == 0)
+        {
+            return true;
+        }
+
+        // Fallback: legacy HKCU\Run entry (users upgrading from <3.2.x)
+        var path = Registry.GetValue(
+            @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
+            Env.SoftName, null);
+        return path as string == Env.ProgramPath;
+    }
+
+    #endregion
+
+    #region Linux
+
     [SupportedOSPlatform("linux")]
     private static void SetLinux(bool enable)
     {
@@ -133,21 +190,6 @@ public class StartUpHelper
         {
             DesktopEntryHelper.RemvoeLinuxDesktopEntry(autoStartFolder);
         }
-    }
-
-    [SupportedOSPlatform("windows")]
-    private static bool CheckWindows()
-    {
-        var psi = new ProcessStartInfo
-        {
-            FileName = "schtasks",
-            Arguments = $"/query /tn \"{Env.SoftName}\"",
-            UseShellExecute = false,
-            CreateNoWindow = true,
-        };
-        var process = Process.Start(psi);
-        process?.WaitForExit();
-        return process?.ExitCode == 0;
     }
 
     [SupportedOSPlatform("linux")]
@@ -169,4 +211,6 @@ public class StartUpHelper
 
         return File.ReadLines(autoStartDestkopFilePath).Any(line => line == $"TryExec={Env.ProgramPath}");
     }
+
+    #endregion
 }

--- a/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
+++ b/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
@@ -1,4 +1,6 @@
-﻿using System.Runtime.Versioning;
+﻿using System.Diagnostics;
+using System.Runtime.Versioning;
+using System.Security.Principal;
 using Microsoft.Win32;
 using SyncClipboard.Core.Commons;
 
@@ -39,15 +41,130 @@ public class StartUpHelper
     }
 
     [SupportedOSPlatform("windows")]
+    private static bool IsElevated()
+    {
+        using var identity = WindowsIdentity.GetCurrent();
+        return new WindowsPrincipal(identity).IsInRole(WindowsBuiltInRole.Administrator);
+    }
+
+    [SupportedOSPlatform("windows")]
     private static void SetWindows(bool enable)
     {
         if (enable)
         {
-            Registry.SetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run", Env.SoftName, Env.ProgramPath);
+            if (IsElevated())
+            {
+                // Running elevated: must use Task Scheduler — HKCU\Run is blocked by UAC
+                CreateTaskViaCom();
+                CleanupRegistryKey();
+            }
+            else
+            {
+                // Running normally: use registry — schtasks /rl highest would fail without elevation
+                SetRegistry(true);
+                DeleteTask();
+            }
         }
         else
         {
-            Registry.CurrentUser.OpenSubKey(@"Software\Microsoft\Windows\CurrentVersion\Run", true)?.DeleteValue(Env.SoftName, false);
+            SetRegistry(false);
+            DeleteTask();
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void CreateTaskViaCom()
+    {
+        try
+        {
+            var schedulerType = Type.GetTypeFromProgID("Schedule.Service", true)!;
+            dynamic scheduler = Activator.CreateInstance(schedulerType)!;
+            scheduler.Connect();
+            dynamic folder = scheduler.GetFolder("\\");
+            dynamic taskDef = scheduler.NewTask(0);
+
+            taskDef.Principal.RunLevel = 1; // TASK_RUNLEVEL_HIGHEST
+            taskDef.Settings.DisallowStartIfOnBatteries = false;
+            taskDef.Settings.StopIfGoingOnBatteries = false;
+            taskDef.Triggers.Create(9); // TASK_TRIGGER_LOGON
+
+            dynamic action = taskDef.Actions.Create(0); // TASK_ACTION_EXEC
+            action.Path = Env.ProgramPath;
+            action.WorkingDirectory = Env.ProgramDirectory;
+
+            // 6 = TASK_CREATE_OR_UPDATE, 3 = TASK_LOGON_INTERACTIVE_TOKEN
+            folder.RegisterTaskDefinition(Env.SoftName, taskDef, 6, null, null, 3, null);
+        }
+        catch
+        {
+            // Fallback: schtasks CLI (no WorkingDirectory — may fail for WinUI3/self-contained apps)
+            try
+            {
+                var psi = new ProcessStartInfo
+                {
+                    FileName = "schtasks",
+                    Arguments = $"/create /tn \"{Env.SoftName}\" /tr \"\\\"{Env.ProgramPath}\\\"\" /sc onlogon /rl highest /f",
+                    UseShellExecute = false,
+                    CreateNoWindow = true,
+                };
+                Process.Start(psi)?.WaitForExit();
+            }
+            catch
+            {
+                // Both methods failed — give up silently
+            }
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void DeleteTask()
+    {
+        try
+        {
+            var psi = new ProcessStartInfo
+            {
+                FileName = "schtasks",
+                Arguments = $"/delete /tn \"{Env.SoftName}\" /f",
+                UseShellExecute = false,
+                CreateNoWindow = true,
+            };
+            Process.Start(psi)?.WaitForExit();
+        }
+        catch
+        {
+            // Task may not exist
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void SetRegistry(bool enable)
+    {
+        if (enable)
+        {
+            Registry.SetValue(
+                @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
+                Env.SoftName, Env.ProgramPath);
+        }
+        else
+        {
+            Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Run", true)
+                ?.DeleteValue(Env.SoftName, false);
+        }
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void CleanupRegistryKey()
+    {
+        try
+        {
+            Registry.CurrentUser.OpenSubKey(
+                @"Software\Microsoft\Windows\CurrentVersion\Run", true)
+                ?.DeleteValue(Env.SoftName, false);
+        }
+        catch
+        {
+            // Key may not exist
         }
     }
 
@@ -73,7 +190,25 @@ public class StartUpHelper
     [SupportedOSPlatform("windows")]
     private static bool CheckWindows()
     {
-        var path = Registry.GetValue(@"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run", Env.SoftName, null);
+        // Check task scheduler first
+        var psi = new ProcessStartInfo
+        {
+            FileName = "schtasks",
+            Arguments = $"/query /tn \"{Env.SoftName}\"",
+            UseShellExecute = false,
+            CreateNoWindow = true,
+        };
+        var process = Process.Start(psi);
+        process?.WaitForExit();
+        if (process?.ExitCode == 0)
+        {
+            return true;
+        }
+
+        // Fallback: check old registry method
+        var path = Registry.GetValue(
+            @"HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\Run",
+            Env.SoftName, null);
         return path as string == Env.ProgramPath;
     }
 

--- a/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
+++ b/src/SyncClipboard.Core/Utilities/StartUpHelper.cs
@@ -336,6 +336,34 @@ public class StartUpHelper
         string ProgramPath,
         string ProgramDirectory);
 
+    private sealed record WindowsTaskSnapshot(
+        WindowsTaskLookupStatus Status,
+        WindowsStartupTaskInfo? Task,
+        string? Xml,
+        string? SecurityDescriptor)
+    {
+        public bool HasCompleteRollbackData =>
+            Status != WindowsTaskLookupStatus.Error
+            && (Status != WindowsTaskLookupStatus.Found
+                || (Xml is not null && SecurityDescriptor is not null));
+    }
+
+    private sealed record WindowsStartupState(
+        string TaskName,
+        WindowsTaskSnapshot CurrentTask,
+        WindowsTaskLookupStatus LegacyTaskStatus,
+        WindowsTaskSnapshot? LegacyTask,
+        WindowsStartupRegistryEntry? RegistryEntry)
+    {
+        public bool CanChange =>
+            CurrentTask.HasCompleteRollbackData
+            && LegacyTaskStatus != WindowsTaskLookupStatus.Error
+            && (LegacyTask?.HasCompleteRollbackData ?? true);
+
+        public string? LegacyTaskName =>
+            LegacyTask is null ? null : Env.SoftName;
+    }
+
     internal static string GetWindowsTaskName(string appName, string userId) => $"{appName}-{userId}";
 
     [SupportedOSPlatform("windows")]
@@ -416,27 +444,67 @@ public class StartUpHelper
         string programPath,
         string programDirectory)
     {
-        if (task is null
-            || !PathsEqual(task.ExecutablePath, programPath)
-            || !string.IsNullOrEmpty(task.Arguments)
-            || !PathsEqual(task.WorkingDirectory, programDirectory)
-            || task.ActionCount != 1
-            || !string.Equals(task.PrincipalUserId, userId, StringComparison.OrdinalIgnoreCase)
-            || task.PrincipalLogonType != 3
-            || !string.Equals(task.TriggerUserId, userId, StringComparison.OrdinalIgnoreCase)
-            || task.TriggerCount != 1
-            || !task.Enabled
-            || !task.TriggerEnabled
-            || task.DisallowStartIfOnBatteries
-            || task.StopIfGoingOnBatteries
-            || task.ExecutionTimeLimit != "PT0S"
-            || task.RunLevel is not TaskRunLevelLeastPrivilege and not TaskRunLevelHighest)
+        if (task is null)
+        {
+            return false;
+        }
+
+        return IsExpectedWindowsTaskAction(task, programPath, programDirectory)
+            && IsExpectedWindowsTaskPrincipal(task, userId)
+            && IsExpectedWindowsTaskSettings(task)
+            && IsExpectedWindowsTaskRunLevel(task, runAsAdmin);
+    }
+
+    private static bool IsExpectedWindowsTaskAction(
+        WindowsStartupTaskInfo task,
+        string programPath,
+        string programDirectory)
+    {
+        return PathsEqual(task.ExecutablePath, programPath)
+            && string.IsNullOrEmpty(task.Arguments)
+            && PathsEqual(task.WorkingDirectory, programDirectory)
+            && task.ActionCount == 1;
+    }
+
+    private static bool IsExpectedWindowsTaskPrincipal(
+        WindowsStartupTaskInfo task,
+        string userId)
+    {
+        return string.Equals(
+                task.PrincipalUserId,
+                userId,
+                StringComparison.OrdinalIgnoreCase)
+            && task.PrincipalLogonType == 3
+            && string.Equals(
+                task.TriggerUserId,
+                userId,
+                StringComparison.OrdinalIgnoreCase)
+            && task.TriggerCount == 1;
+    }
+
+    private static bool IsExpectedWindowsTaskSettings(WindowsStartupTaskInfo task)
+    {
+        return task.Enabled
+            && task.TriggerEnabled
+            && !task.DisallowStartIfOnBatteries
+            && !task.StopIfGoingOnBatteries
+            && task.ExecutionTimeLimit == "PT0S";
+    }
+
+    private static bool IsExpectedWindowsTaskRunLevel(
+        WindowsStartupTaskInfo task,
+        bool? runAsAdmin)
+    {
+        if (task.RunLevel is not TaskRunLevelLeastPrivilege and not TaskRunLevelHighest)
         {
             return false;
         }
 
         return runAsAdmin is null
-            || task.RunLevel == (runAsAdmin.Value ? TaskRunLevelHighest : TaskRunLevelLeastPrivilege);
+            || task.RunLevel
+            == (runAsAdmin.Value
+                ? TaskRunLevelHighest
+                : TaskRunLevelLeastPrivilege);
     }
 
     internal static bool NeedsWindowsStartupMigrationElevation(
@@ -750,166 +818,104 @@ public class StartUpHelper
     [SupportedOSPlatform("windows")]
     private static bool TryEnableWindowsStartup(string userId, string userName, bool runAsAdmin)
     {
-        var taskName = GetWindowsTaskName(Env.SoftName, userId);
-        var previousTaskStatus = GetWindowsTaskLookupStatus(taskName);
-        var previousTaskXml = previousTaskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskXml(taskName)
-            : null;
-        var previousTaskSecurityDescriptor =
-            previousTaskStatus == WindowsTaskLookupStatus.Found
-                ? GetWindowsTaskSecurityDescriptor(taskName)
-                : null;
-        var previousTask = previousTaskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskInfo(taskName)
-            : null;
-        var legacyTaskStatus = GetWindowsTaskLookupStatus(Env.SoftName);
-        var legacyTaskCandidate = legacyTaskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskInfo(Env.SoftName)
-            : null;
-        var legacyTask = IsLegacyTaskForCurrentUser(legacyTaskCandidate, userId, userName)
-            ? legacyTaskCandidate
-            : null;
-        var legacyTaskXml = legacyTask is null
-            ? null
-            : GetWindowsTaskXml(Env.SoftName);
-        var legacyTaskSecurityDescriptor = legacyTask is null
-            ? null
-            : GetWindowsTaskSecurityDescriptor(Env.SoftName);
-        var registryEntry = GetLegacyRegistryEntry();
-
-        if (previousTaskStatus == WindowsTaskLookupStatus.Error
-            || legacyTaskStatus == WindowsTaskLookupStatus.Error
-            || (previousTaskStatus == WindowsTaskLookupStatus.Found
-                && (previousTaskXml is null
-                    || previousTaskSecurityDescriptor is null))
-            || (legacyTask is not null
-                && (legacyTaskXml is null
-                    || legacyTaskSecurityDescriptor is null)))
-        {
-            return false;
-        }
-
-        if (NeedsWindowsStartupMigrationElevation(runAsAdmin, previousTask, legacyTask))
-        {
-            return TryRunElevatedWindowsStartupTransaction(
-                enable: true,
-                taskName,
-                userId,
-                runAsAdmin,
-                previousTaskXml,
-                previousTaskSecurityDescriptor,
-                legacyTask is null ? null : Env.SoftName,
-                legacyTaskXml,
-                legacyTaskSecurityDescriptor,
-                registryEntry);
-        }
-
-        if (!TryRegisterWindowsTaskWithoutElevation(taskName, userId, runAsAdmin)
-            || !IsExpectedWindowsTask(
-                GetWindowsTaskInfo(taskName),
-                userId,
-                runAsAdmin,
-                Env.ProgramPath,
-                Env.ProgramDirectory))
-        {
-            RestoreWindowsTask(taskName, previousTaskXml, previousTask);
-            return TryRunElevatedWindowsStartupTransaction(
-                enable: true,
-                taskName,
-                userId,
-                runAsAdmin,
-                previousTaskXml,
-                previousTaskSecurityDescriptor,
-                legacyTask is null ? null : Env.SoftName,
-                legacyTaskXml,
-                legacyTaskSecurityDescriptor,
-                registryEntry);
-        }
-
-        if (!TryRemoveLegacyWindowsStartup(userId, userName))
-        {
-            RestoreWindowsTask(Env.SoftName, legacyTaskXml, legacyTask);
-            RestoreLegacyRegistryEntry(registryEntry);
-            RestoreWindowsTask(taskName, previousTaskXml, previousTask);
-            return TryRunElevatedWindowsStartupTransaction(
-                enable: true,
-                taskName,
-                userId,
-                runAsAdmin,
-                previousTaskXml,
-                previousTaskSecurityDescriptor,
-                legacyTask is null ? null : Env.SoftName,
-                legacyTaskXml,
-                legacyTaskSecurityDescriptor,
-                registryEntry);
-        }
-
-        return true;
-    }
-
-    [SupportedOSPlatform("windows")]
-    private static bool TryDisableWindowsStartup(string userId, string userName)
-    {
-        var taskName = GetWindowsTaskName(Env.SoftName, userId);
-        var taskStatus = GetWindowsTaskLookupStatus(taskName);
-        var task = taskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskInfo(taskName)
-            : null;
-        var taskXml = taskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskXml(taskName)
-            : null;
-        var taskSecurityDescriptor = taskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskSecurityDescriptor(taskName)
-            : null;
-        var legacyTaskStatus = GetWindowsTaskLookupStatus(Env.SoftName);
-        var legacyTaskCandidate = legacyTaskStatus == WindowsTaskLookupStatus.Found
-            ? GetWindowsTaskInfo(Env.SoftName)
-            : null;
-        var legacyTask = IsLegacyTaskForCurrentUser(legacyTaskCandidate, userId, userName)
-            ? legacyTaskCandidate
-            : null;
-        var legacyTaskXml = legacyTask is null
-            ? null
-            : GetWindowsTaskXml(Env.SoftName);
-        var legacyTaskSecurityDescriptor = legacyTask is null
-            ? null
-            : GetWindowsTaskSecurityDescriptor(Env.SoftName);
-        var registryEntry = GetLegacyRegistryEntry();
-
-        if (taskStatus == WindowsTaskLookupStatus.Error
-            || legacyTaskStatus == WindowsTaskLookupStatus.Error
-            || (taskStatus == WindowsTaskLookupStatus.Found
-                && (taskXml is null
-                    || taskSecurityDescriptor is null))
-            || (legacyTask is not null
-                && (legacyTaskXml is null
-                    || legacyTaskSecurityDescriptor is null)))
+        var state = CaptureWindowsStartupState(userId, userName);
+        if (!state.CanChange)
         {
             return false;
         }
 
         if (NeedsWindowsStartupMigrationElevation(
-            runAsAdmin: false,
-            currentTask: task,
-            legacyTask))
+                runAsAdmin,
+                state.CurrentTask.Task,
+                state.LegacyTask?.Task))
+        {
+            return TryRunElevatedWindowsStartupTransaction(
+                enable: true,
+                userId,
+                runAsAdmin,
+                state);
+        }
+
+        return TryEnableWindowsStartupWithoutElevation(
+            userId,
+            userName,
+            runAsAdmin,
+            state);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryEnableWindowsStartupWithoutElevation(
+        string userId,
+        string userName,
+        bool runAsAdmin,
+        WindowsStartupState state)
+    {
+        var registered = TryRegisterWindowsTaskWithoutElevation(
+                state.TaskName,
+                userId,
+                runAsAdmin)
+            && IsExpectedWindowsTask(
+                GetWindowsTaskInfo(state.TaskName),
+                userId,
+                runAsAdmin,
+                Env.ProgramPath,
+                Env.ProgramDirectory);
+        if (!registered)
+        {
+            RestoreWindowsStartupState(state);
+            return TryRunElevatedWindowsStartupTransaction(
+                enable: true,
+                userId,
+                runAsAdmin,
+                state);
+        }
+
+        if (TryRemoveLegacyWindowsStartup(userId, userName))
+        {
+            return true;
+        }
+
+        RestoreWindowsStartupState(state);
+        return TryRunElevatedWindowsStartupTransaction(
+            enable: true,
+            userId,
+            runAsAdmin,
+            state);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryDisableWindowsStartup(string userId, string userName)
+    {
+        var state = CaptureWindowsStartupState(userId, userName);
+        if (!state.CanChange)
+        {
+            return false;
+        }
+
+        if (NeedsWindowsStartupMigrationElevation(
+                runAsAdmin: false,
+                currentTask: state.CurrentTask.Task,
+                state.LegacyTask?.Task))
         {
             return TryRunElevatedWindowsStartupTransaction(
                     enable: false,
-                    taskName,
                     userId,
                     runAsAdmin: false,
-                    taskXml,
-                    taskSecurityDescriptor,
-                    legacyTask is null ? null : Env.SoftName,
-                    legacyTaskXml,
-                    legacyTaskSecurityDescriptor,
-                    registryEntry)
+                    state)
                 && !CheckWindows();
         }
 
-        var removed = (taskStatus == WindowsTaskLookupStatus.NotFound
-                || TryDeleteWindowsTask(taskName, allowElevation: false))
-            && (legacyTask is null
+        return TryDisableWindowsStartupWithoutElevation(userId, state);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryDisableWindowsStartupWithoutElevation(
+        string userId,
+        WindowsStartupState state)
+    {
+        var removed = (state.CurrentTask.Status == WindowsTaskLookupStatus.NotFound
+                || TryDeleteWindowsTask(state.TaskName, allowElevation: false))
+            && (state.LegacyTask is null
                 || TryDeleteWindowsTask(Env.SoftName, allowElevation: false))
             && TryDeleteLegacyRegistryEntry()
             && !CheckWindows();
@@ -918,21 +924,87 @@ public class StartUpHelper
             return true;
         }
 
-        RestoreLegacyRegistryEntry(registryEntry);
-        RestoreWindowsTask(Env.SoftName, legacyTaskXml, legacyTask);
-        RestoreWindowsTask(taskName, taskXml, task);
+        RestoreWindowsStartupState(state);
         return TryRunElevatedWindowsStartupTransaction(
                 enable: false,
-                taskName,
                 userId,
                 runAsAdmin: false,
-                taskXml,
-                taskSecurityDescriptor,
-                legacyTask is null ? null : Env.SoftName,
-                legacyTaskXml,
-                legacyTaskSecurityDescriptor,
-                registryEntry)
+                state)
             && !CheckWindows();
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static WindowsStartupState CaptureWindowsStartupState(
+        string userId,
+        string userName)
+    {
+        var taskName = GetWindowsTaskName(Env.SoftName, userId);
+        var currentTask = CaptureWindowsTaskSnapshot(taskName);
+        var legacyCandidate = CaptureWindowsTaskSnapshot(Env.SoftName);
+        var legacyTask = IsLegacyTaskForCurrentUser(
+            legacyCandidate.Task,
+            userId,
+            userName)
+            ? legacyCandidate
+            : null;
+
+        return new WindowsStartupState(
+            taskName,
+            currentTask,
+            legacyCandidate.Status,
+            legacyTask,
+            GetLegacyRegistryEntry());
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static WindowsTaskSnapshot CaptureWindowsTaskSnapshot(string taskName)
+    {
+        var status = GetWindowsTaskLookupStatus(taskName);
+        return status == WindowsTaskLookupStatus.Found
+            ? new WindowsTaskSnapshot(
+                status,
+                GetWindowsTaskInfo(taskName),
+                GetWindowsTaskXml(taskName),
+                GetWindowsTaskSecurityDescriptor(taskName))
+            : new WindowsTaskSnapshot(status, null, null, null);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static void RestoreWindowsStartupState(WindowsStartupState state)
+    {
+        RestoreLegacyRegistryEntry(state.RegistryEntry);
+        if (state.LegacyTask is not null)
+        {
+            RestoreWindowsTask(
+                Env.SoftName,
+                state.LegacyTask.Xml,
+                state.LegacyTask.Task);
+        }
+
+        RestoreWindowsTask(
+            state.TaskName,
+            state.CurrentTask.Xml,
+            state.CurrentTask.Task);
+    }
+
+    [SupportedOSPlatform("windows")]
+    private static bool TryRunElevatedWindowsStartupTransaction(
+        bool enable,
+        string userId,
+        bool runAsAdmin,
+        WindowsStartupState state)
+    {
+        return TryRunElevatedWindowsStartupTransaction(
+            enable,
+            state.TaskName,
+            userId,
+            runAsAdmin,
+            state.CurrentTask.Xml,
+            state.CurrentTask.SecurityDescriptor,
+            state.LegacyTaskName,
+            state.LegacyTask?.Xml,
+            state.LegacyTask?.SecurityDescriptor,
+            state.RegistryEntry);
     }
 
     [SupportedOSPlatform("windows")]
@@ -1038,57 +1110,87 @@ public class StartUpHelper
     {
         try
         {
-            var newTaskXml = enable
-                ? NormalizeTaskXml(
-                    BuildWindowsTaskXml(
-                        userId,
-                        runAsAdmin,
-                        Env.ProgramPath,
-                        Env.ProgramDirectory))
-                : null;
-
-            var manifest = new WindowsStartupMigrationManifest(
+            var manifest = CreateWindowsStartupMigrationManifest(
+                enable,
                 taskName,
-                newTaskXml,
-                enable && !runAsAdmin
-                    ? BuildWindowsTaskSecurityDescriptor(userId)
-                    : null,
-                DeleteNewTask: !enable && previousTaskXml is not null,
-                previousTaskXml is null ? null : NormalizeTaskXml(previousTaskXml),
+                userId,
+                runAsAdmin,
+                previousTaskXml,
                 previousTaskSecurityDescriptor,
                 legacyTaskName,
-                legacyTaskXml is null ? null : NormalizeTaskXml(legacyTaskXml),
+                legacyTaskXml,
                 legacyTaskSecurityDescriptor,
-                registryEntry?.Value,
-                registryEntry is null ? null : (int)registryEntry.ValueKind,
-                RunKeyPath,
-                Env.SoftName,
-                userId,
-                runAsAdmin ? TaskRunLevelHighest : TaskRunLevelLeastPrivilege,
-                Env.ProgramPath,
-                Env.ProgramDirectory);
+                registryEntry);
             var command = BuildElevatedPowerShellCommand(
                 JsonSerializer.Serialize(manifest),
                 WindowsStartupMigrationScript);
             var startInfo = CreateElevatedPowerShellStartInfo(command);
-            if (startInfo.ArgumentList[^1].Length >= 30_000)
-            {
-                return false;
-            }
-
-            using var process = Process.Start(startInfo);
-            if (process is null)
-            {
-                return false;
-            }
-
-            process.WaitForExit();
-            return process.ExitCode == 0;
+            return RunElevatedWindowsStartupProcess(startInfo);
         }
         catch
         {
             return false;
         }
+    }
+
+    private static WindowsStartupMigrationManifest CreateWindowsStartupMigrationManifest(
+        bool enable,
+        string taskName,
+        string userId,
+        bool runAsAdmin,
+        string? previousTaskXml,
+        string? previousTaskSecurityDescriptor,
+        string? legacyTaskName,
+        string? legacyTaskXml,
+        string? legacyTaskSecurityDescriptor,
+        WindowsStartupRegistryEntry? registryEntry)
+    {
+        var newTaskXml = enable
+            ? NormalizeTaskXml(
+                BuildWindowsTaskXml(
+                    userId,
+                    runAsAdmin,
+                    Env.ProgramPath,
+                    Env.ProgramDirectory))
+            : null;
+
+        return new WindowsStartupMigrationManifest(
+            taskName,
+            newTaskXml,
+            enable && !runAsAdmin
+                ? BuildWindowsTaskSecurityDescriptor(userId)
+                : null,
+            DeleteNewTask: !enable && previousTaskXml is not null,
+            previousTaskXml is null ? null : NormalizeTaskXml(previousTaskXml),
+            previousTaskSecurityDescriptor,
+            legacyTaskName,
+            legacyTaskXml is null ? null : NormalizeTaskXml(legacyTaskXml),
+            legacyTaskSecurityDescriptor,
+            registryEntry?.Value,
+            registryEntry is null ? null : (int)registryEntry.ValueKind,
+            RunKeyPath,
+            Env.SoftName,
+            userId,
+            runAsAdmin ? TaskRunLevelHighest : TaskRunLevelLeastPrivilege,
+            Env.ProgramPath,
+            Env.ProgramDirectory);
+    }
+
+    private static bool RunElevatedWindowsStartupProcess(ProcessStartInfo startInfo)
+    {
+        if (startInfo.ArgumentList[^1].Length >= 30_000)
+        {
+            return false;
+        }
+
+        using var process = Process.Start(startInfo);
+        if (process is null)
+        {
+            return false;
+        }
+
+        process.WaitForExit();
+        return process.ExitCode == 0;
     }
 
     private static void WriteTaskXml(string path, string xml)

--- a/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
@@ -221,24 +221,42 @@ public partial class SystemSettingViewModel : ObservableObject
         get => StartUpHelper.Status();
         set
         {
-            StartUpHelper.Set(value, RunAsAdminOnStartUp);
+            var runAsAdmin = RunAsAdminOnStartUp;
+            if (value
+                && ProgramConfig.RunAsAdminOnStartUp
+                && !StartUpHelper.CanCurrentWindowsUserRunAsAdmin())
+            {
+                ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = false };
+            }
+
+            StartUpHelper.TrySet(value, runAsAdmin);
             OnPropertyChanged(nameof(StartUpWithSystem));
+            OnPropertyChanged(nameof(RunAsAdminOnStartUp));
         }
     }
 
     public bool RunAsAdminOnStartUp
     {
-        get => ProgramConfig.RunAsAdminOnStartUp;
+        get => StartUpHelper.TryGetRunAsAdmin(out var runAsAdmin)
+            ? runAsAdmin
+            : ProgramConfig.RunAsAdminOnStartUp
+                && StartUpHelper.CanCurrentWindowsUserRunAsAdmin();
         set
         {
-            // Recreate the task first if auto-start is active, then persist config.
-            if (StartUpHelper.Status())
+            if (value && !StartUpHelper.CanCurrentWindowsUserRunAsAdmin())
             {
-                StartUpHelper.Set(true, value);
+                OnPropertyChanged(nameof(RunAsAdminOnStartUp));
+                return;
             }
-            // Only persist the requested value if the task still exists;
-            // if creation silently failed, save false (the effective state).
-            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value && StartUpHelper.Status() };
+
+            if (StartUpHelper.Status()
+                && !StartUpHelper.TrySet(enable: true, runAsAdmin: value))
+            {
+                OnPropertyChanged(nameof(RunAsAdminOnStartUp));
+                return;
+            }
+
+            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value };
         }
     }
 

--- a/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
@@ -232,12 +232,13 @@ public partial class SystemSettingViewModel : ObservableObject
         set
         {
             // Recreate the task first if auto-start is active, then persist config.
-            // If task creation fails, the old value stays in config.
             if (StartUpHelper.Status())
             {
                 StartUpHelper.Set(true, value);
             }
-            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value };
+            // Only persist the requested value if the task still exists;
+            // if creation silently failed, save false (the effective state).
+            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value && StartUpHelper.Status() };
         }
     }
 

--- a/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
@@ -231,12 +231,13 @@ public partial class SystemSettingViewModel : ObservableObject
         get => ProgramConfig.RunAsAdminOnStartUp;
         set
         {
-            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value };
-            // Recreate the task with the new RunLevel if auto-start is active
+            // Recreate the task first if auto-start is active, then persist config.
+            // If task creation fails, the old value stays in config.
             if (StartUpHelper.Status())
             {
                 StartUpHelper.Set(true, value);
             }
+            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value };
         }
     }
 

--- a/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
@@ -65,7 +65,6 @@ public partial class SystemSettingViewModel : ObservableObject
         Language = Languages.FirstOrDefault(x => x.LocaleTag == value.Language) ?? Languages[0];
         Theme = Themes.FirstOrDefault(x => x.Key == ProgramConfig.Theme) ?? Themes[0];
         OnPropertyChanged(nameof(RunAsAdminOnStartUp));
-        OnPropertyChanged(nameof(IsRunAsAdminEnabled));
         _configManager.SetConfig(value);
     }
 
@@ -224,7 +223,6 @@ public partial class SystemSettingViewModel : ObservableObject
         {
             StartUpHelper.Set(value, RunAsAdminOnStartUp);
             OnPropertyChanged(nameof(StartUpWithSystem));
-            OnPropertyChanged(nameof(IsRunAsAdminEnabled));
         }
     }
 
@@ -241,8 +239,6 @@ public partial class SystemSettingViewModel : ObservableObject
             }
         }
     }
-
-    public bool IsRunAsAdminEnabled => StartUpHelper.Status();
 
     /// <summary>
     /// Called by code-behind after a folder is picked by the user.

--- a/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/SystemSettingViewModel.cs
@@ -64,6 +64,8 @@ public partial class SystemSettingViewModel : ObservableObject
         Font = value.Font;
         Language = Languages.FirstOrDefault(x => x.LocaleTag == value.Language) ?? Languages[0];
         Theme = Themes.FirstOrDefault(x => x.Key == ProgramConfig.Theme) ?? Themes[0];
+        OnPropertyChanged(nameof(RunAsAdminOnStartUp));
+        OnPropertyChanged(nameof(IsRunAsAdminEnabled));
         _configManager.SetConfig(value);
     }
 
@@ -188,6 +190,8 @@ public partial class SystemSettingViewModel : ObservableObject
 
     public bool ShowStartUpSetting { get; } = OperatingSystem.IsWindows() || OperatingSystem.IsLinux();
 
+    public bool ShowRunAsAdminSetting { get; } = OperatingSystem.IsWindows();
+
     public bool ShowPortableLocationSetting { get; } = OperatingSystem.IsWindows();
 
     public static string AppDataDirectory => Env.AppDataDirectory;
@@ -218,10 +222,27 @@ public partial class SystemSettingViewModel : ObservableObject
         get => StartUpHelper.Status();
         set
         {
-            StartUpHelper.Set(value);
+            StartUpHelper.Set(value, RunAsAdminOnStartUp);
             OnPropertyChanged(nameof(StartUpWithSystem));
+            OnPropertyChanged(nameof(IsRunAsAdminEnabled));
         }
     }
+
+    public bool RunAsAdminOnStartUp
+    {
+        get => ProgramConfig.RunAsAdminOnStartUp;
+        set
+        {
+            ProgramConfig = ProgramConfig with { RunAsAdminOnStartUp = value };
+            // Recreate the task with the new RunLevel if auto-start is active
+            if (StartUpHelper.Status())
+            {
+                StartUpHelper.Set(true, value);
+            }
+        }
+    }
+
+    public bool IsRunAsAdminEnabled => StartUpHelper.Status();
 
     /// <summary>
     /// Called by code-behind after a folder is picked by the user.

--- a/src/SyncClipboard.Desktop/Views/SystemSettingPage.axaml
+++ b/src/SyncClipboard.Desktop/Views/SystemSettingPage.axaml
@@ -27,7 +27,7 @@
                 </ui:SettingsExpanderItem>
                 <ui:SettingsExpanderItem Content="{x:Static i18n:Strings.RunAsAdminOnStartUp}" IsVisible="{Binding ShowRunAsAdminSetting}">
                     <ui:SettingsExpanderItem.Footer>
-                        <ToggleSwitch OnContent="{x:Static i18n:Strings.On}" OffContent="{x:Static i18n:Strings.Off}" IsChecked="{Binding RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{Binding IsRunAsAdminEnabled, Mode=OneWay}" />
+                        <ToggleSwitch OnContent="{x:Static i18n:Strings.On}" OffContent="{x:Static i18n:Strings.Off}" IsChecked="{Binding RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{Binding StartUpWithSystem, Mode=OneWay}" />
                     </ui:SettingsExpanderItem.Footer>
                 </ui:SettingsExpanderItem>
                 <ui:SettingsExpanderItem Content="{x:Static i18n:Strings.HideOnStartup}">

--- a/src/SyncClipboard.Desktop/Views/SystemSettingPage.axaml
+++ b/src/SyncClipboard.Desktop/Views/SystemSettingPage.axaml
@@ -25,6 +25,11 @@
                         <ToggleSwitch OnContent="{x:Static i18n:Strings.On}" OffContent="{x:Static i18n:Strings.Off}" IsChecked="{Binding StartUpWithSystem, Mode=TwoWay}" />
                     </ui:SettingsExpanderItem.Footer>
                 </ui:SettingsExpanderItem>
+                <ui:SettingsExpanderItem Content="{x:Static i18n:Strings.RunAsAdminOnStartUp}" IsVisible="{Binding ShowRunAsAdminSetting}">
+                    <ui:SettingsExpanderItem.Footer>
+                        <ToggleSwitch OnContent="{x:Static i18n:Strings.On}" OffContent="{x:Static i18n:Strings.Off}" IsChecked="{Binding RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{Binding IsRunAsAdminEnabled, Mode=OneWay}" />
+                    </ui:SettingsExpanderItem.Footer>
+                </ui:SettingsExpanderItem>
                 <ui:SettingsExpanderItem Content="{x:Static i18n:Strings.HideOnStartup}">
                     <ui:SettingsExpanderItem.Footer>
                         <ToggleSwitch OnContent="{x:Static i18n:Strings.On}" OffContent="{x:Static i18n:Strings.Off}" IsChecked="{Binding HideWindowOnStartUp, Mode=TwoWay}" />

--- a/src/SyncClipboard.Test/StartUpHelperTests.cs
+++ b/src/SyncClipboard.Test/StartUpHelperTests.cs
@@ -1,0 +1,380 @@
+using System.Security.Principal;
+using System.Text;
+using System.Xml.Linq;
+using SyncClipboard.Core.Utilities;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class StartUpHelperTests
+{
+    private const string UserSid = "S-1-5-21-1000";
+    private const string ProgramPath = @"C:\Apps\SyncClipboard\SyncClipboard.exe";
+    private const string ProgramDirectory = @"C:\Apps\SyncClipboard";
+
+    [TestMethod]
+    [DataRow(false, "LeastPrivilege")]
+    [DataRow(true, "HighestAvailable")]
+    public void BuildWindowsTaskXmlContainsRequiredStartupSettings(bool runAsAdmin, string expectedRunLevel)
+    {
+        var xml = StartUpHelper.BuildWindowsTaskXml(
+            UserSid,
+            runAsAdmin,
+            ProgramPath,
+            ProgramDirectory);
+        var document = XDocument.Parse(xml);
+        var ns = document.Root!.Name.Namespace;
+
+        Assert.AreEqual(UserSid, document.Descendants(ns + "Principal").Single().Element(ns + "UserId")!.Value);
+        Assert.AreEqual("InteractiveToken", document.Descendants(ns + "LogonType").Single().Value);
+        Assert.AreEqual(expectedRunLevel, document.Descendants(ns + "RunLevel").Single().Value);
+        Assert.AreEqual(UserSid, document.Descendants(ns + "LogonTrigger").Single().Element(ns + "UserId")!.Value);
+        Assert.AreEqual("false", document.Descendants(ns + "DisallowStartIfOnBatteries").Single().Value);
+        Assert.AreEqual("false", document.Descendants(ns + "StopIfGoingOnBatteries").Single().Value);
+        Assert.AreEqual("PT0S", document.Descendants(ns + "ExecutionTimeLimit").Single().Value);
+        Assert.AreEqual(ProgramPath, document.Descendants(ns + "Command").Single().Value);
+        Assert.IsFalse(document.Descendants(ns + "Arguments").Any());
+        Assert.AreEqual(ProgramDirectory, document.Descendants(ns + "WorkingDirectory").Single().Value);
+
+        var securityDescriptor = document.Descendants(ns + "SecurityDescriptor").SingleOrDefault();
+        if (runAsAdmin)
+        {
+            Assert.IsNull(securityDescriptor);
+        }
+        else
+        {
+            Assert.IsNotNull(securityDescriptor);
+            Assert.Contains($"(A;;FA;;;{UserSid})", securityDescriptor.Value);
+        }
+    }
+
+    [TestMethod]
+    public void GetWindowsTaskNameScopesTaskToCurrentUser()
+    {
+        Assert.AreEqual(
+            $"SyncClipboard-{UserSid}",
+            StartUpHelper.GetWindowsTaskName("SyncClipboard", UserSid));
+    }
+
+    [TestMethod]
+    public void NormalizeWindowsUserIdResolvesCurrentAccountToSid()
+    {
+        if (!OperatingSystem.IsWindows())
+        {
+            Assert.Inconclusive("Windows account translation is only available on Windows.");
+            return;
+        }
+
+        using var identity = WindowsIdentity.GetCurrent();
+        var expectedSid = identity.User!.Value;
+
+        Assert.AreEqual(expectedSid, StartUpHelper.NormalizeWindowsUserId(expectedSid));
+        Assert.AreEqual(expectedSid, StartUpHelper.NormalizeWindowsUserId(identity.Name));
+        Assert.AreEqual(expectedSid, StartUpHelper.NormalizeWindowsUserId(Environment.UserName));
+    }
+
+    [TestMethod]
+    [DataRow(false, false, "")]
+    [DataRow(true, true, "runas")]
+    public void CreateSchtasksStartInfoRequestsElevationOnlyWhenRequired(
+        bool elevate,
+        bool expectedUseShellExecute,
+        string expectedVerb)
+    {
+        var arguments = new[] { "/Create", "/TN", $"SyncClipboard-{UserSid}", "/F" };
+
+        var startInfo = StartUpHelper.CreateSchtasksStartInfo(arguments, elevate);
+
+        Assert.AreEqual("schtasks.exe", startInfo.FileName);
+        Assert.AreEqual(expectedUseShellExecute, startInfo.UseShellExecute);
+        Assert.AreEqual(expectedVerb, startInfo.Verb);
+        CollectionAssert.AreEqual(arguments, startInfo.ArgumentList.ToArray());
+    }
+
+    [TestMethod]
+    public void CreateElevatedPowerShellStartInfoUsesSingleRunAsProcess()
+    {
+        const string command = "Write-Output 'trusted command'";
+
+        var startInfo = StartUpHelper.CreateElevatedPowerShellStartInfo(command);
+
+        Assert.AreEqual("powershell.exe", startInfo.FileName);
+        Assert.IsTrue(startInfo.UseShellExecute);
+        Assert.AreEqual("runas", startInfo.Verb);
+        Assert.AreEqual("-NoProfile", startInfo.ArgumentList[0]);
+        Assert.AreEqual("-NonInteractive", startInfo.ArgumentList[1]);
+        Assert.AreEqual("-ExecutionPolicy", startInfo.ArgumentList[2]);
+        Assert.AreEqual("Bypass", startInfo.ArgumentList[3]);
+        Assert.AreEqual("-EncodedCommand", startInfo.ArgumentList[4]);
+
+        var bootstrap = Encoding.Unicode.GetString(
+            Convert.FromBase64String(startInfo.ArgumentList[5]));
+        Assert.IsFalse(bootstrap.Contains(command, StringComparison.Ordinal));
+        Assert.IsTrue(bootstrap.Contains("GZipStream", StringComparison.Ordinal));
+        Assert.IsTrue(bootstrap.Contains("ScriptBlock", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void WindowsStartupMigrationRequestsElevationForEveryPrivilegedTaskTransition()
+    {
+        var normalTask = CreateTaskInfo(runAsAdmin: false);
+        var adminTask = CreateTaskInfo(runAsAdmin: true);
+
+        Assert.IsFalse(StartUpHelper.NeedsWindowsStartupMigrationElevation(
+            runAsAdmin: false,
+            currentTask: normalTask,
+            legacyTask: normalTask));
+        Assert.IsTrue(StartUpHelper.NeedsWindowsStartupMigrationElevation(
+            runAsAdmin: true,
+            currentTask: normalTask,
+            legacyTask: normalTask));
+        Assert.IsTrue(StartUpHelper.NeedsWindowsStartupMigrationElevation(
+            runAsAdmin: false,
+            currentTask: adminTask,
+            legacyTask: normalTask));
+        Assert.IsTrue(StartUpHelper.NeedsWindowsStartupMigrationElevation(
+            runAsAdmin: false,
+            currentTask: normalTask,
+            legacyTask: adminTask));
+    }
+
+    [TestMethod]
+    public void AutomaticMigrationRequiresDefinitivelyMissingNewTaskAndReadableLegacyState()
+    {
+        Assert.IsTrue(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.NotFound,
+            WindowsTaskLookupStatus.NotFound,
+            legacyTaskIsExpectedAndUnprivileged: false,
+            registryEntryExists: true));
+        Assert.IsTrue(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.NotFound,
+            WindowsTaskLookupStatus.Found,
+            legacyTaskIsExpectedAndUnprivileged: true,
+            registryEntryExists: false));
+        Assert.IsFalse(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.Found,
+            WindowsTaskLookupStatus.NotFound,
+            legacyTaskIsExpectedAndUnprivileged: false,
+            registryEntryExists: true));
+        Assert.IsFalse(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.Error,
+            WindowsTaskLookupStatus.NotFound,
+            legacyTaskIsExpectedAndUnprivileged: false,
+            registryEntryExists: true));
+        Assert.IsFalse(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.NotFound,
+            WindowsTaskLookupStatus.Error,
+            legacyTaskIsExpectedAndUnprivileged: false,
+            registryEntryExists: true));
+        Assert.IsFalse(StartUpHelper.CanAutomaticallyMigrateWindowsStartup(
+            WindowsTaskLookupStatus.NotFound,
+            WindowsTaskLookupStatus.Found,
+            legacyTaskIsExpectedAndUnprivileged: false,
+            registryEntryExists: true));
+    }
+
+    [TestMethod]
+    public void AdministratorCapabilityUsesTokenGroupMembership()
+    {
+        Assert.IsTrue(StartUpHelper.ContainsBuiltinAdministratorsSid(
+            ["S-1-5-32-545", "S-1-5-32-544"]));
+        Assert.IsFalse(StartUpHelper.ContainsBuiltinAdministratorsSid(
+            ["S-1-5-32-545"]));
+    }
+
+    [TestMethod]
+    public void IsExpectedLegacyWindowsTaskRejectsUnexpectedBehavior()
+    {
+        const string userName = @"DOMAIN\User";
+        var task = CreateTaskInfo(runAsAdmin: false) with { TriggerUserId = string.Empty };
+
+        Assert.IsTrue(StartUpHelper.IsExpectedLegacyWindowsTask(
+            task,
+            UserSid,
+            userName,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedLegacyWindowsTask(
+            task with { Arguments = "--unexpected" },
+            UserSid,
+            userName,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedLegacyWindowsTask(
+            task with { ActionCount = 2 },
+            UserSid,
+            userName,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedLegacyWindowsTask(
+            task with { TriggerCount = 2 },
+            UserSid,
+            userName,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedLegacyWindowsTask(
+            task with { ExecutionTimeLimit = "P3D" },
+            UserSid,
+            userName,
+            ProgramPath,
+            ProgramDirectory));
+    }
+
+    [TestMethod]
+    public void BuildElevatedPowerShellCommandEmbedsCompressedPayload()
+    {
+        const string manifestJson = """{"ProgramPath":"C:\\应用\\SyncClipboard.exe"}""";
+        const string script = "if ([string]::IsNullOrEmpty($ManifestJson)) { exit 1 }";
+
+        var command = StartUpHelper.BuildElevatedPowerShellCommand(
+            manifestJson,
+            script);
+
+        Assert.IsFalse(command.Contains(manifestJson, StringComparison.Ordinal));
+        Assert.IsTrue(command.EndsWith(script, StringComparison.Ordinal));
+        Assert.IsTrue(command.Contains("GZipStream", StringComparison.Ordinal));
+    }
+
+    [TestMethod]
+    public void IsExpectedWindowsTaskAcceptsExactTask()
+    {
+        var task = CreateTaskInfo(runAsAdmin: true);
+
+        Assert.IsTrue(StartUpHelper.IsExpectedWindowsTask(
+            task,
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+    }
+
+    [TestMethod]
+    public void IsExpectedWindowsTaskRejectsMismatchedTaskFields()
+    {
+        var task = CreateTaskInfo(runAsAdmin: true);
+
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { ExecutablePath = @"C:\Old\SyncClipboard.exe" },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { WorkingDirectory = @"C:\Old" },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { PrincipalUserId = "S-1-5-21-2000" },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { TriggerUserId = "S-1-5-21-2000" },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { RunLevel = 0 },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { Arguments = "--unexpected" },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { ActionCount = 2 },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { TriggerCount = 2 },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { PrincipalLogonType = 2 },
+            UserSid,
+            runAsAdmin: true,
+            ProgramPath,
+            ProgramDirectory));
+    }
+
+    [TestMethod]
+    public void IsExpectedWindowsTaskCanIgnoreRunLevelForStartupStatus()
+    {
+        var task = CreateTaskInfo(runAsAdmin: true);
+
+        Assert.IsTrue(StartUpHelper.IsExpectedWindowsTask(
+            task,
+            UserSid,
+            runAsAdmin: null,
+            ProgramPath,
+            ProgramDirectory));
+    }
+
+    [TestMethod]
+    public void IsExpectedWindowsTaskRejectsDisabledOrRestrictedTask()
+    {
+        var task = CreateTaskInfo(runAsAdmin: false);
+
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { Enabled = false },
+            UserSid,
+            runAsAdmin: false,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { TriggerEnabled = false },
+            UserSid,
+            runAsAdmin: false,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { DisallowStartIfOnBatteries = true },
+            UserSid,
+            runAsAdmin: false,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { StopIfGoingOnBatteries = true },
+            UserSid,
+            runAsAdmin: false,
+            ProgramPath,
+            ProgramDirectory));
+        Assert.IsFalse(StartUpHelper.IsExpectedWindowsTask(
+            task with { ExecutionTimeLimit = "P3D" },
+            UserSid,
+            runAsAdmin: false,
+            ProgramPath,
+            ProgramDirectory));
+    }
+
+    private static WindowsStartupTaskInfo CreateTaskInfo(bool runAsAdmin)
+    {
+        return new WindowsStartupTaskInfo(
+            ProgramPath,
+            Arguments: string.Empty,
+            ProgramDirectory,
+            ActionCount: 1,
+            UserSid,
+            PrincipalLogonType: 3,
+            UserSid,
+            TriggerCount: 1,
+            runAsAdmin ? 1 : 0,
+            Enabled: true,
+            TriggerEnabled: true,
+            DisallowStartIfOnBatteries: false,
+            StopIfGoingOnBatteries: false,
+            ExecutionTimeLimit: "PT0S");
+    }
+}

--- a/src/SyncClipboard.WinUI3/Views/SystemSettingPage.xaml
+++ b/src/SyncClipboard.WinUI3/Views/SystemSettingPage.xaml
@@ -21,7 +21,7 @@
                     <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.StartUpWithSystem, Mode=TwoWay}" />
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="{x:Bind i18n:Strings.RunAsAdminOnStartUp}">
-                    <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{x:Bind _viewModel.IsRunAsAdminEnabled, Mode=OneWay}" />
+                    <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{x:Bind _viewModel.StartUpWithSystem, Mode=OneWay}" />
                 </ui:SettingsCard>
                 <ui:SettingsCard Header="{x:Bind i18n:Strings.HideOnStartup}">
                     <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.HideWindowOnStartUp, Mode=TwoWay}" />

--- a/src/SyncClipboard.WinUI3/Views/SystemSettingPage.xaml
+++ b/src/SyncClipboard.WinUI3/Views/SystemSettingPage.xaml
@@ -20,6 +20,9 @@
                 <ui:SettingsCard Header="{x:Bind i18n:Strings.RunAtSystemStartup}">
                     <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.StartUpWithSystem, Mode=TwoWay}" />
                 </ui:SettingsCard>
+                <ui:SettingsCard Header="{x:Bind i18n:Strings.RunAsAdminOnStartUp}">
+                    <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.RunAsAdminOnStartUp, Mode=TwoWay}" IsEnabled="{x:Bind _viewModel.IsRunAsAdminEnabled, Mode=OneWay}" />
+                </ui:SettingsCard>
                 <ui:SettingsCard Header="{x:Bind i18n:Strings.HideOnStartup}">
                     <ToggleSwitch OnContent="{x:Bind i18n:Strings.On}" OffContent="{x:Bind i18n:Strings.Off}" IsOn="{x:Bind _viewModel.HideWindowOnStartUp, Mode=TwoWay}" />
                 </ui:SettingsCard>


### PR DESCRIPTION
## Fix for #384

Windows auto-start now uses Task Scheduler for every mode. The current process elevation state is no longer used to choose between Task Scheduler and `HKCU\Run`.

### Behavior

- Creates a per-user task named `SyncClipboard-<SID>` with a user-scoped logon trigger.
- Stores the executable path, working directory, `InteractiveToken`, battery settings, unlimited execution time, and the requested run level in the task definition.
- Adds a persisted `RunAsAdminOnStartUp` preference. While a valid task exists, the UI reflects its actual run level; while startup is disabled, it falls back to the saved preference.
- Keeps the administrator toggle disabled when auto-start is off and rejects unsupported elevated startup for standard-user accounts.
- Migrates the legacy fixed-name task and matching `HKCU\Run` entry only after the replacement is verified.
- Uses a single UAC transaction when privileged changes are required, with task/registry/DACL rollback on failure or cancellation.
- Treats malformed, inaccessible, stale-path, disabled, restricted, wrong-user, or wrong-run-level tasks as inactive instead of accepting task-name existence alone.

### Compatibility and safety

- Preserves the existing `Set(bool)` API and adds explicit success-returning operations for UI rollback.
- Normal tasks grant the original user task-management rights; highest-level tasks remain protected from non-elevated modification.
- Elevated transaction data is compressed and embedded in the command, avoiding parent-process temporary-input races.

### Verification

- 16 Windows startup unit tests pass.
- WinUI3 x64 Release build passes with 0 warnings and 0 errors.
- Avalonia Windows x64 Release build passes with 0 errors (existing Magick.NET audit warnings remain).
- Real Task Scheduler checks cover normal/admin registration, admin-to-normal downgrade, non-elevated deletion, legacy migration cleanup, rollback, DACL restoration, and temporary-task cleanup.
- PowerShell transaction and encoded launcher both parse successfully and remain below the Windows command-line limit.