### PR TITLE
fix: 修复历史记录重排后的选中状态问题

### DIFF
--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.Selection.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.Selection.cs
@@ -191,6 +191,41 @@ public partial class HistoryViewModel
         return true;
     }
 
+    internal static int GetSelectionTargetIndexBeforeRemoval(
+        int itemCount,
+        int selectedIndex,
+        int removedIndex)
+    {
+        if (selectedIndex < 0 || selectedIndex >= itemCount)
+            return -1;
+
+        if (selectedIndex != removedIndex)
+            return selectedIndex;
+
+        if (removedIndex + 1 < itemCount)
+            return removedIndex + 1;
+
+        return removedIndex - 1;
+    }
+
+    private HistoryRecordVM? PrepareSelectionForRecordReplacement(HistoryRecordVM removedRecord)
+    {
+        if (IsMultiSelecting || SelectedItem is null)
+            return null;
+
+        var items = (IList<HistoryRecordVM>)HistoryItems;
+        var targetIndex = GetSelectionTargetIndexBeforeRemoval(
+            items.Count,
+            SelectedIndex,
+            items.IndexOf(removedRecord));
+        var target = targetIndex >= 0 ? items[targetIndex] : null;
+
+        // Reset the UI selection before the collection emits remove/add events.
+        // The target is restored by identity after the record has been repositioned.
+        ClearSelectedItem();
+        return target;
+    }
+
     [RelayCommand]
     public async Task DeleteItem(HistoryRecordVM record)
     {

--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.Selection.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.Selection.cs
@@ -79,7 +79,6 @@ public partial class HistoryViewModel
 
     private void InitializeSelection()
     {
-        HistoryItems.CollectionChanged += OnHistoryItemsCollectionChanged;
         VisibleSelectedItems = new ReadOnlyObservableCollection<HistoryRecordVM>(visibleSelectedItems);
         selectionSummaryRefreshTask = new(
             (pending, next) => pending | next,
@@ -135,7 +134,9 @@ public partial class HistoryViewModel
             || e.NewItems?.Count is not > 0)
             return;
 
-        SelectedIndex += e.NewItems.Count;
+        var adjustedIndex = SelectedIndex + e.NewItems.Count;
+        if (adjustedIndex < HistoryItemCount)
+            SelectedIndex = adjustedIndex;
     }
 
     public void HandleRecordClick(HistoryRecordVM record, bool ctrlPressed, bool shiftPressed)

--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
@@ -1080,10 +1080,13 @@ public partial class HistoryViewModel : ObservableObject
     {
         try
         {
+            var selectionAfterReplacement = PrepareSelectionForRecordReplacement(oldR);
             ClearVisibleRecordSelection(oldR);
             allHistoryItems.Remove(oldR);
             if (newR != null)
                 InsertHistoryInOrder(newR);
+            if (selectionAfterReplacement is not null)
+                SelectSingleRecord(selectionAfterReplacement);
         }
         catch
         {

--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
@@ -973,6 +973,10 @@ public partial class HistoryViewModel : ObservableObject
     public async Task Init(IWindow window)
     {
         this.window = window;
+        // Both desktop views bind HistoryItems before calling Init. Subscribe here
+        // so the controls process collection changes before selection is adjusted.
+        HistoryItems.CollectionChanged -= OnHistoryItemsCollectionChanged;
+        HistoryItems.CollectionChanged += OnHistoryItemsCollectionChanged;
         if (!OperatingSystem.IsLinux())
         {
             _foregroundWindowTrackingService.SetHistoryWindow(window.GetNativeWindowInfo());

--- a/src/SyncClipboard.Test/HistoryViewModelSelectionTests.cs
+++ b/src/SyncClipboard.Test/HistoryViewModelSelectionTests.cs
@@ -1,0 +1,40 @@
+using SyncClipboard.Core.ViewModels;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class HistoryViewModelSelectionTests
+{
+    [TestMethod]
+    public void RemovingSelectedRecord_SelectsRecordOriginallyAfterIt()
+    {
+        var targetIndex = HistoryViewModel.GetSelectionTargetIndexBeforeRemoval(
+            itemCount: 5,
+            selectedIndex: 2,
+            removedIndex: 2);
+
+        Assert.AreEqual(3, targetIndex);
+    }
+
+    [TestMethod]
+    public void RemovingLastSelectedRecord_SelectsRecordOriginallyBeforeIt()
+    {
+        var targetIndex = HistoryViewModel.GetSelectionTargetIndexBeforeRemoval(
+            itemCount: 5,
+            selectedIndex: 4,
+            removedIndex: 4);
+
+        Assert.AreEqual(3, targetIndex);
+    }
+
+    [TestMethod]
+    public void RemovingDifferentRecord_PreservesSelectedRecord()
+    {
+        var targetIndex = HistoryViewModel.GetSelectionTargetIndexBeforeRemoval(
+            itemCount: 5,
+            selectedIndex: 3,
+            removedIndex: 1);
+
+        Assert.AreEqual(3, targetIndex);
+    }
+}

--- a/src/SyncClipboard.WinUI3/Views/HistoryWindow.xaml.cs
+++ b/src/SyncClipboard.WinUI3/Views/HistoryWindow.xaml.cs
@@ -416,6 +416,9 @@ public sealed partial class HistoryWindow : Window, IWindow
 
     private void Grid_KeyDown(object _, KeyRoutedEventArgs e)
     {
+        if (e.Key == VirtualKey.None)
+            return;
+
         if (e.Key == VirtualKey.Escape && _viewModel.IsMultiSelecting)
         {
             _viewModel.ExitMultiSelect();


### PR DESCRIPTION
## 修改内容

- 历史记录按最后复制时间重排时，按记录身份恢复原位置的下一条记录，避免选中项多跳一条
- 调整集合变化监听的订阅时机，让 UI 控件先处理集合更新，再补偿 SelectedIndex
- 增加索引范围保护，避免 WinUI3 在高频复制时因临时越界索引异常退出
- 添加历史记录选择边界回归测试

## 验证

- SyncClipboard.Test：102/102 通过
- Core 代码格式检查通过

## 说明

WinUI3 需要 Windows 环境，当前未在本机 macOS 上执行平台构建。