### PR TITLE
fix: 修复历史窗口按钮焦点并补充快捷键

### DIFF
--- a/src/SyncClipboard.Core/I18n/Strings.resx
+++ b/src/SyncClipboard.Core/I18n/Strings.resx
@@ -546,6 +546,7 @@ Ctrl+Home: Scroll to top
 Ctrl+End: Scroll to bottom
 Ctrl+S: Toggle star
 Ctrl+Shift+S: Toggle starred only
+Ctrl+Shift+T: Toggle always on top
 Ctrl+D: Delete item
 Ctrl+P: Toggle preview panel
 ↑/↓: Navigate items

--- a/src/SyncClipboard.Core/I18n/Strings.zh-CN.resx
+++ b/src/SyncClipboard.Core/I18n/Strings.zh-CN.resx
@@ -547,6 +547,7 @@ Ctrl+Home：滚动到顶部
 Ctrl+End：滚动到底部
 Ctrl+S：切换收藏
 Ctrl+Shift+S：切换仅显示收藏
+Ctrl+Shift+T：切换窗口置顶
 Ctrl+D：删除项目
 Ctrl+P：切换预览面板
 Tab/Shift+Tab：切换筛选器

--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
@@ -298,8 +298,11 @@ public partial class HistoryViewModel : ObservableObject
         get => runtimeConfig.GetConfig<HistoryWindowConfig>().IsTopmost;
         set
         {
+            if (value == IsTopmost) return;
+
             window?.SetTopmost(value);
             runtimeConfig.SetConfig(runtimeConfig.GetConfig<HistoryWindowConfig>() with { IsTopmost = value });
+            OnPropertyChanged(nameof(IsTopmost));
         }
     }
 
@@ -823,14 +826,31 @@ public partial class HistoryViewModel : ObservableObject
         window?.ScrollToSelectedItem();
     }
 
-    public bool HandleKeyPress(Key key, bool isShiftPressed = false, bool isAltPressed = false, bool isCtrlPressed = false)
+    public bool HandleKeyPress(
+        Key key,
+        bool isShiftPressed = false,
+        bool isAltPressed = false,
+        bool isCtrlPressed = false,
+        bool isMetaPressed = false)
     {
+        var isCloseModifierPressed = OperatingSystem.IsMacOS()
+            ? isMetaPressed && !isCtrlPressed
+            : isCtrlPressed && !isMetaPressed;
+        if (key == Key.W && isCloseModifierPressed && !isShiftPressed && !isAltPressed)
+        {
+            Close();
+            return true;
+        }
+
         if (isCtrlPressed && isShiftPressed && !isAltPressed)
         {
             switch (key)
             {
                 case Key.S:
                     OnlyShowStarred = !OnlyShowStarred;
+                    return true;
+                case Key.T:
+                    IsTopmost = !IsTopmost;
                     return true;
             }
         }

--- a/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
+++ b/src/SyncClipboard.Core/ViewModels/HistoryViewModel.cs
@@ -833,10 +833,7 @@ public partial class HistoryViewModel : ObservableObject
         bool isCtrlPressed = false,
         bool isMetaPressed = false)
     {
-        var isCloseModifierPressed = OperatingSystem.IsMacOS()
-            ? isMetaPressed && !isCtrlPressed
-            : isCtrlPressed && !isMetaPressed;
-        if (key == Key.W && isCloseModifierPressed && !isShiftPressed && !isAltPressed)
+        if (IsCloseShortcut(key, isShiftPressed, isAltPressed, isCtrlPressed, isMetaPressed))
         {
             Close();
             return true;
@@ -905,6 +902,21 @@ public partial class HistoryViewModel : ObservableObject
             default:
                 return false;
         }
+    }
+
+    private static bool IsCloseShortcut(
+        Key key,
+        bool isShiftPressed,
+        bool isAltPressed,
+        bool isCtrlPressed,
+        bool isMetaPressed)
+    {
+        if (key != Key.W || isShiftPressed || isAltPressed)
+            return false;
+
+        return OperatingSystem.IsMacOS()
+            ? isMetaPressed && !isCtrlPressed
+            : isCtrlPressed && !isMetaPressed;
     }
 
     private async void HandleToggleStarShortcut()

--- a/src/SyncClipboard.Desktop/Views/HistoryWindow.axaml.cs
+++ b/src/SyncClipboard.Desktop/Views/HistoryWindow.axaml.cs
@@ -134,6 +134,7 @@ public partial class HistoryWindow : Window, IWindow
         var isShiftPressed = e.KeyModifiers.HasFlag(KeyModifiers.Shift);
         var isAltPressed = e.KeyModifiers.HasFlag(KeyModifiers.Alt);
         var isCtrlPressed = e.KeyModifiers.HasFlag(KeyModifiers.Control);
+        var isMetaPressed = e.KeyModifiers.HasFlag(KeyModifiers.Meta);
 
         var key = Utilities.KeyboardMap.ConvertFromAvalonia(e.Key);
 
@@ -143,7 +144,7 @@ public partial class HistoryWindow : Window, IWindow
             return;
         }
 
-        var handled = _viewModel.HandleKeyPress(key.Value, isShiftPressed, isAltPressed, isCtrlPressed);
+        var handled = _viewModel.HandleKeyPress(key.Value, isShiftPressed, isAltPressed, isCtrlPressed, isMetaPressed);
 
         if (handled)
         {

--- a/src/SyncClipboard.WinUI3/Views/HistoryWindow.xaml
+++ b/src/SyncClipboard.WinUI3/Views/HistoryWindow.xaml
@@ -23,11 +23,26 @@
           KeyboardAcceleratorPlacementMode="Hidden"
           RowDefinitions="Auto, Auto, *">
         <Grid.Resources>
+            <!--  Keep focus on the search box so history keyboard shortcuts remain available.  -->
             <Style TargetType="Button" BasedOn="{StaticResource DateTimePickerFlyoutButtonStyle}">
                 <Setter Property="Height" Value="28" />
                 <Setter Property="Width" Value="28" />
                 <Setter Property="Padding" Value="0,0,0,0" />
                 <Setter Property="FontSize" Value="12" />
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="AllowFocusOnInteraction" Value="False" />
+            </Style>
+            <Style TargetType="ToggleButton" BasedOn="{StaticResource IconToggleButtonStyle}">
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="AllowFocusOnInteraction" Value="False" />
+            </Style>
+            <Style TargetType="AppBarButton">
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="AllowFocusOnInteraction" Value="False" />
+            </Style>
+            <Style TargetType="CheckBox">
+                <Setter Property="IsTabStop" Value="False" />
+                <Setter Property="AllowFocusOnInteraction" Value="False" />
             </Style>
             <Style TargetType="FontIcon">
                 <Setter Property="FontSize" Value="12" />
@@ -79,13 +94,16 @@
                         HorizontalAlignment="Right"
                         Orientation="Horizontal"
                         Spacing="4">
-                <ToggleButton Style="{StaticResource IconToggleButtonStyle}" ToolTipService.ToolTip="{x:Bind i18n:Strings.WindowTopmost}" IsChecked="{x:Bind _viewModel.IsTopmost, Mode=TwoWay}">
+                <ToggleButton ToolTipService.ToolTip="{x:Bind i18n:Strings.WindowTopmost}"
+                              IsChecked="{x:Bind _viewModel.IsTopmost, Mode=TwoWay}">
                     <FontIcon Glyph="&#xE840;" />
                 </ToggleButton>
-                <ToggleButton Style="{StaticResource IconToggleButtonStyle}" ToolTipService.ToolTip="{x:Bind i18n:Strings.OnlyShowStarred}" IsChecked="{x:Bind _viewModel.OnlyShowStarred, Mode=TwoWay}">
+                <ToggleButton ToolTipService.ToolTip="{x:Bind i18n:Strings.OnlyShowStarred}"
+                              IsChecked="{x:Bind _viewModel.OnlyShowStarred, Mode=TwoWay}">
                     <FontIcon Glyph="&#xE734;" />
                 </ToggleButton>
-                <ToggleButton Style="{StaticResource IconToggleButtonStyle}" ToolTipService.ToolTip="{x:Bind i18n:Strings.PreviewPanel}" IsChecked="{x:Bind _viewModel.ShowPreviewPanel, Mode=TwoWay}">
+                <ToggleButton ToolTipService.ToolTip="{x:Bind i18n:Strings.PreviewPanel}"
+                              IsChecked="{x:Bind _viewModel.ShowPreviewPanel, Mode=TwoWay}">
                     <FontIcon Glyph="&#xE90C;" />
                 </ToggleButton>
                 <Button x:Name="_MenuButton"
@@ -189,7 +207,6 @@
                                       Padding="0"
                                       HorizontalAlignment="Center"
                                       VerticalAlignment="Center"
-                                      IsTabStop="False"
                                       IsChecked="{x:Bind IsSelected, Mode=OneWay}"
                                       Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(local:HistoryListModeProxy.Current.IsMultiSelecting), Mode=OneWay}"
                                       Click="RecordSelectionCheckBox_Click" />
@@ -271,7 +288,9 @@
                                 IsDynamicOverflowEnabled="False"
                                 OverflowButtonVisibility="Collapsed"
                                 Background="Transparent">
-                        <AppBarButton Label="{x:Bind i18n:Strings.HistoryMultiSelectAll}" LabelPosition="Default" Command="{x:Bind _viewModel.ToggleCurrentFilterSelectionCommand}">
+                        <AppBarButton Label="{x:Bind i18n:Strings.HistoryMultiSelectAll}"
+                                      LabelPosition="Default"
+                                      Command="{x:Bind _viewModel.ToggleCurrentFilterSelectionCommand}">
                             <AppBarButton.Icon>
                                 <FontIcon x:Name="_SelectAllIcon" Glyph="&#xE739;" />
                             </AppBarButton.Icon>
@@ -280,7 +299,9 @@
                                       LabelPosition="Default"
                                       Icon="Delete"
                                       Command="{x:Bind _viewModel.ConfirmDeleteSelectedCommand}" />
-                        <AppBarButton Label="{x:Bind i18n:Strings.HistoryMultiSelectStar}" LabelPosition="Default" Command="{x:Bind _viewModel.ConfirmToggleSelectedStarredCommand}">
+                        <AppBarButton Label="{x:Bind i18n:Strings.HistoryMultiSelectStar}"
+                                      LabelPosition="Default"
+                                      Command="{x:Bind _viewModel.ConfirmToggleSelectedStarredCommand}">
                             <AppBarButton.Icon>
                                 <SymbolIcon x:Name="_ToggleStarIcon" Symbol="OutlineStar" />
                             </AppBarButton.Icon>

--- a/src/SyncClipboard.WinUI3/Views/RecordControlBar.xaml
+++ b/src/SyncClipboard.WinUI3/Views/RecordControlBar.xaml
@@ -17,11 +17,10 @@
         </Button>
         <!--  Sync buttons container  -->
         <StackPanel Orientation="Horizontal" Spacing="4" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(ViewModel.EnableSyncHistory), Mode=OneWay}">
-            <Button Click="DownloadButtonClicked" IsTabStop="False" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowDownloadButton), Mode=OneWay}">
+            <Button Click="DownloadButtonClicked" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowDownloadButton), Mode=OneWay}">
                 <FontIcon Glyph="&#xE896;" />
             </Button>
             <Button Click="CancelDownloadButtonClicked"
-                    IsTabStop="False"
                     Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowDownloadProgress), Mode=OneWay}"
                     ToolTipService.ToolTip="{x:Bind i18n:Strings.CancelDownload}">
                 <ProgressRing Width="16"
@@ -30,12 +29,11 @@
                               Value="{x:Bind Record.DownloadProgress, Mode=OneWay}" />
             </Button>
             <!--  Upload button  -->
-            <Button Click="UploadButtonClicked" IsTabStop="False" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowUploadButton), Mode=OneWay}">
+            <Button Click="UploadButtonClicked" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowUploadButton), Mode=OneWay}">
                 <FontIcon Glyph="&#xE898;" />
             </Button>
             <!--  Cancel upload button with progress ring  -->
             <Button Click="CancelUploadButtonClicked"
-                    IsTabStop="False"
                     Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.ShowUploadProgress), Mode=OneWay}"
                     ToolTipService.ToolTip="{x:Bind i18n:Strings.CancelUpload}">
                 <ProgressRing Width="16"
@@ -44,16 +42,16 @@
                               Value="{x:Bind Record.UploadProgress, Mode=OneWay}" />
             </Button>
         </StackPanel>
-        <Button Click="CopyButtonClicked" IsTabStop="False" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.IsLocalFileReady), Mode=OneWay}">
+        <Button Click="CopyButtonClicked" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.IsLocalFileReady), Mode=OneWay}">
             <FontIcon Glyph="&#xE8C8;" />
         </Button>
-        <Button Click="PasteButtonClicked" IsTabStop="False" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.IsLocalFileReady), Mode=OneWay}">
+        <Button Click="PasteButtonClicked" Visibility="{x:Bind vc:ConvertMethod.BoolToVisibility(Record.IsLocalFileReady), Mode=OneWay}">
             <FontIcon Glyph="&#xE77F;" />
         </Button>
-        <Button Click="StarButtonClicked" IsTabStop="False">
+        <Button Click="StarButtonClicked">
             <FontIcon Glyph="{x:Bind vc:ConvertMethod.ToStarIcon(Record.Stared), Mode=OneWay}" />
         </Button>
-        <Button Click="DeleteButtonClicked" IsTabStop="False">
+        <Button Click="DeleteButtonClicked">
             <FontIcon Glyph="&#xE74D;" />
         </Button>
     </StackPanel>


### PR DESCRIPTION
## 概要
- 为 WinUI 历史窗口按钮统一禁用交互焦点，避免方向键等面板快捷键失效
- 添加 Ctrl+Shift+T 切换窗口置顶，并同步按钮状态与中英文说明
- 添加平台化关闭快捷键：macOS 使用 Cmd+W，其他平台使用 Ctrl+W

## 验证
- dotnet build src/SyncClipboard.Desktop/SyncClipboard.Desktop.csproj --no-restore
- DOTNET_ROLL_FORWARD=Major dotnet test src/SyncClipboard.Test/SyncClipboard.Test.csproj --no-restore（102 个测试通过）
- WinUI XAML 已通过 XML 与 diff 检查；WinUI3 完整构建需 Windows 环境