### PR TITLE
fix: 数据储存型服务器上的大文件，桌面客户端循环反复下载

### DIFF
--- a/src/SyncClipboard.Core/RemoteServer/Adapter/IOfficialServerAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/IOfficialServerAdapter.cs
@@ -1,6 +1,6 @@
 namespace SyncClipboard.Core.RemoteServer.Adapter;
 
-public interface IOfficialServerAdapter : IStorageBasedServerAdapter
+public interface IOfficialServerAdapter : IServerAdapter
 {
     public void StartListening();
     public void StopListening();

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/IServerAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/IServerAdapter.cs
@@ -1,10 +1,23 @@
 using System.Net;
+using SyncClipboard.Core.Models;
 using SyncClipboard.Core.Models.UserConfigs;
 
 namespace SyncClipboard.Core.RemoteServer.Adapter;
 
 public interface IServerAdapter
 {
+    Task InitializeAsync(CancellationToken cancellationToken = default);
+
+    Task<ProfileDto?> GetProfileAsync(CancellationToken cancellationToken = default);
+
+    Task SetProfileAsync(ProfileDto profileDto, CancellationToken cancellationToken = default);
+
+    Task UploadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default);
+
+    Task DownloadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default);
+
+    Task CleanupTempFilesAsync(CancellationToken cancellationToken = default);
+
     Task TestConnectionAsync(CancellationToken cancellationToken = default);
     void SetConfig(object config, SyncConfig syncConfig);
     void ApplyConfig();

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/IStorageBasedServerAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/IStorageBasedServerAdapter.cs
@@ -6,19 +6,7 @@ public sealed record StorageProfileSnapshot(ProfileDto Profile, string? Version)
 
 public interface IStorageBasedServerAdapter : IServerAdapter
 {
-    Task InitializeAsync(CancellationToken cancellationToken = default);
-
-    Task<ProfileDto?> GetProfileAsync(CancellationToken cancellationToken = default);
-
     Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default);
 
-    Task SetProfileAsync(ProfileDto profileDto, CancellationToken cancellationToken = default);
-
     Task<bool> TrySetProfileAsync(ProfileDto profileDto, string? expectedVersion, CancellationToken cancellationToken = default);
-
-    Task UploadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default);
-
-    Task DownloadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default);
-
-    Task CleanupTempFilesAsync(CancellationToken cancellationToken = default);
 }

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/IStorageBasedServerAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/IStorageBasedServerAdapter.cs
@@ -2,13 +2,19 @@ using SyncClipboard.Core.Models;
 
 namespace SyncClipboard.Core.RemoteServer.Adapter;
 
+public sealed record StorageProfileSnapshot(ProfileDto Profile, string? Version);
+
 public interface IStorageBasedServerAdapter : IServerAdapter
 {
     Task InitializeAsync(CancellationToken cancellationToken = default);
 
     Task<ProfileDto?> GetProfileAsync(CancellationToken cancellationToken = default);
 
+    Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default);
+
     Task SetProfileAsync(ProfileDto profileDto, CancellationToken cancellationToken = default);
+
+    Task<bool> TrySetProfileAsync(ProfileDto profileDto, string? expectedVersion, CancellationToken cancellationToken = default);
 
     Task UploadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default);
 

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/OfficialServer/OfficialAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/OfficialServer/OfficialAdapter.cs
@@ -184,6 +184,19 @@ public sealed class OfficialAdapter(
         return _webDavAdapter.SetProfileAsync(profileDto, cancellationToken);
     }
 
+    public Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        return _webDavAdapter.GetProfileSnapshotAsync(cancellationToken);
+    }
+
+    public Task<bool> TrySetProfileAsync(
+        ProfileDto profileDto,
+        string? expectedVersion,
+        CancellationToken cancellationToken = default)
+    {
+        return _webDavAdapter.TrySetProfileAsync(profileDto, expectedVersion, cancellationToken);
+    }
+
     public Task DownloadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
         return _webDavAdapter.DownloadFileAsync(fileName, localPath, progress, cancellationToken);

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/OfficialServer/OfficialAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/OfficialServer/OfficialAdapter.cs
@@ -184,19 +184,6 @@ public sealed class OfficialAdapter(
         return _webDavAdapter.SetProfileAsync(profileDto, cancellationToken);
     }
 
-    public Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
-    {
-        return _webDavAdapter.GetProfileSnapshotAsync(cancellationToken);
-    }
-
-    public Task<bool> TrySetProfileAsync(
-        ProfileDto profileDto,
-        string? expectedVersion,
-        CancellationToken cancellationToken = default)
-    {
-        return _webDavAdapter.TrySetProfileAsync(profileDto, expectedVersion, cancellationToken);
-    }
-
     public Task DownloadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
         return _webDavAdapter.DownloadFileAsync(fileName, localPath, progress, cancellationToken);

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/S3Server/S3Adapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/S3Server/S3Adapter.cs
@@ -93,6 +93,11 @@ public sealed class S3Adapter : IServerAdapter<S3Config>, IStorageBasedServerAda
 
     public async Task<ProfileDto?> GetProfileAsync(CancellationToken cancellationToken = default)
     {
+        return (await GetProfileSnapshotAsync(cancellationToken))?.Profile;
+    }
+
+    public async Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
+    {
         ValidateConfig();
         try
         {
@@ -104,7 +109,8 @@ public sealed class S3Adapter : IServerAdapter<S3Config>, IStorageBasedServerAda
             using var response = await _s3Client.GetObjectAsync(request, cancellationToken);
             using var reader = new StreamReader(response.ResponseStream);
             var json = await reader.ReadToEndAsync(cancellationToken);
-            return JsonSerializer.Deserialize<ProfileDto>(json, JsonSerializerOptions.Web);
+            var profile = JsonSerializer.Deserialize<ProfileDto>(json, JsonSerializerOptions.Web);
+            return profile is null ? null : new StorageProfileSnapshot(profile, response.ETag);
         }
         catch (AmazonS3Exception ex) when (ex.StatusCode == HttpStatusCode.NotFound || ex.ErrorCode == "NoSuchKey")
         {
@@ -125,6 +131,40 @@ public sealed class S3Adapter : IServerAdapter<S3Config>, IStorageBasedServerAda
         };
         ApplyCompatibilityForPut(request);
         await _s3Client.PutObjectAsync(request, cancellationToken);
+    }
+
+    public async Task<bool> TrySetProfileAsync(
+        ProfileDto profileDto,
+        string? expectedVersion,
+        CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(expectedVersion))
+        {
+            return false;
+        }
+
+        ValidateConfig();
+        var json = JsonSerializer.Serialize(profileDto, JsonSerializerOptions.Web);
+        var request = new PutObjectRequest
+        {
+            BucketName = _s3Config.BucketName,
+            Key = BuildObjectKey(RemoteProfilePath),
+            ContentBody = json,
+            ContentType = "application/json; charset=utf-8",
+            IfMatch = expectedVersion
+        };
+        ApplyCompatibilityForPut(request);
+
+        try
+        {
+            await _s3Client.PutObjectAsync(request, cancellationToken);
+            return true;
+        }
+        catch (AmazonS3Exception ex) when (
+            ex.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.Conflict)
+        {
+            return false;
+        }
     }
 
     public async Task UploadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)

--- a/src/SyncClipboard.Core/RemoteServer/Adapter/WebDavServer/WebDavAdapter.cs
+++ b/src/SyncClipboard.Core/RemoteServer/Adapter/WebDavServer/WebDavAdapter.cs
@@ -82,9 +82,29 @@ public sealed class WebDavAdapter : IServerAdapter<WebDavConfig>, IStorageBasedS
         return profileDto;
     }
 
+    public async Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
+    {
+        var (profileDto, version) = await _webDav.GetJsonWithVersion<ProfileDto>(
+            RemoteProfilePath,
+            cancellationToken);
+        return profileDto is null ? null : new StorageProfileSnapshot(profileDto, version);
+    }
+
     public async Task SetProfileAsync(ProfileDto profileDto, CancellationToken cancellationToken = default)
     {
         await _webDav.PutJson(RemoteProfilePath, profileDto, cancellationToken);
+    }
+
+    public Task<bool> TrySetProfileAsync(
+        ProfileDto profileDto,
+        string? expectedVersion,
+        CancellationToken cancellationToken = default)
+    {
+        return _webDav.PutJsonIfVersion(
+            RemoteProfilePath,
+            profileDto,
+            expectedVersion,
+            cancellationToken);
     }
 
     public async Task UploadFileAsync(string fileName, string localPath, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -132,46 +132,39 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
 
     private static bool ShouldFillBack(ProfileDto downloadedProfile, ProfileDto currentProfile)
     {
-        var shouldFillHash = string.IsNullOrEmpty(currentProfile.Hash);
-        var shouldFillSize = currentProfile.Size is null;
-        if (!shouldFillHash && !shouldFillSize)
+        if (!string.IsNullOrEmpty(currentProfile.Hash) && currentProfile.Size is not null)
         {
             return false;
         }
 
-        if (!shouldFillHash &&
-            !string.Equals(currentProfile.Hash, downloadedProfile.Hash, StringComparison.OrdinalIgnoreCase))
+        if (!MatchesKnownProfileMetadata(downloadedProfile, currentProfile))
         {
             return false;
         }
 
-        if (currentProfile.Type != downloadedProfile.Type &&
-            (currentProfile.Type != ProfileType.File || downloadedProfile.Type != ProfileType.Image))
-        {
-            return false;
-        }
-
-        if (!string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (currentProfile.HasData != downloadedProfile.HasData)
-        {
-            return false;
-        }
-
-        if (!string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal))
-        {
-            return false;
-        }
-
-        if (!shouldFillSize && currentProfile.Size != downloadedProfile.Size)
+        if (!MatchesProfileIdentity(downloadedProfile, currentProfile))
         {
             return false;
         }
 
         return true;
+    }
+
+    private static bool MatchesKnownProfileMetadata(ProfileDto downloadedProfile, ProfileDto currentProfile)
+    {
+        return (string.IsNullOrEmpty(currentProfile.Hash) ||
+                string.Equals(currentProfile.Hash, downloadedProfile.Hash, StringComparison.OrdinalIgnoreCase)) &&
+            (currentProfile.Size is null || currentProfile.Size == downloadedProfile.Size);
+    }
+
+    private static bool MatchesProfileIdentity(ProfileDto downloadedProfile, ProfileDto currentProfile)
+    {
+        var typeMatches = currentProfile.Type == downloadedProfile.Type ||
+            (currentProfile.Type == ProfileType.File && downloadedProfile.Type == ProfileType.Image);
+        return typeMatches &&
+            string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal) &&
+            currentProfile.HasData == downloadedProfile.HasData &&
+            string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal);
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -89,10 +89,11 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
 
         try
         {
-            var currentProfile = await _serverAdapter.GetProfileAsync(cancellationToken);
-            if (!CanBackfillRemoteProfileHash(originalProfile, currentProfile))
+            var currentSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
+            if (currentSnapshot is null ||
+                !CanBackfillRemoteProfileHash(originalProfile, currentSnapshot.Profile))
             {
-                _logger.Write("[PULL] Remote profile changed before hash backfill, skipped metadata update.");
+                _logger.Write("[PULL] Remote profile does not meet hash backfill preconditions, skipped metadata update.");
                 return;
             }
 
@@ -102,14 +103,21 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
                 return;
             }
 
-            await _serverAdapter.SetProfileAsync(
-                currentProfile! with { Hash = calculatedHash },
+            var updated = await _serverAdapter.TrySetProfileAsync(
+                currentSnapshot.Profile with { Hash = calculatedHash },
+                currentSnapshot.Version,
                 cancellationToken);
+            if (!updated)
+            {
+                _logger.Write("[PULL] Remote profile changed during hash backfill, skipped metadata update.");
+                return;
+            }
+
             _logger.Write($"[PULL] Backfilled remote profile hash: {calculatedHash}");
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
-            _logger.Write($"[PULL] Failed to backfill remote profile hash: {ex.Message}");
+            _logger.Write($"[PULL] Failed to backfill remote profile hash: {ex}");
         }
     }
 

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -34,7 +34,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
 
     public async Task DownloadProfileDataAsync(Profile profile, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
-        var remoteProfileWithoutHash = await GetRemoteFileProfileWithoutHash(profile, cancellationToken);
+        var remoteSnapshotWithoutHash = await GetRemoteFileProfileWithoutHash(profile, cancellationToken);
         var persistentDir = _profileEnv.GetPersistentDir();
         var dataPath = await profile.NeedsTransferData(persistentDir, cancellationToken);
         if (dataPath is null)
@@ -47,7 +47,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             var fileName = Path.GetFileName(dataPath);
             await _serverAdapter.DownloadFileAsync(fileName, dataPath, progress, cancellationToken);
             await profile.SetAndMoveTransferData(persistentDir, dataPath, cancellationToken);
-            await BackfillRemoteProfileHash(remoteProfileWithoutHash, profile, cancellationToken);
+            await BackfillRemoteProfileHash(remoteSnapshotWithoutHash, profile, cancellationToken);
             _logger.Write($"[PULL] Downloaded {fileName} to {dataPath}");
             _trayIcon.SetStatusString(ServerConstants.StatusName, "Running.");
         }
@@ -64,7 +64,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
         }
     }
 
-    private static async Task<ProfileDto?> GetRemoteFileProfileWithoutHash(
+    private async Task<StorageProfileSnapshot?> GetRemoteFileProfileWithoutHash(
         Profile profile,
         CancellationToken cancellationToken)
     {
@@ -74,15 +74,23 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             return null;
         }
 
-        return await profile.ToProfileDto(cancellationToken);
+        var normalizedProfile = await profile.ToProfileDto(cancellationToken);
+        var remoteSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
+        if (remoteSnapshot is null ||
+            !MatchesNormalizedFileProfile(normalizedProfile, remoteSnapshot.Profile))
+        {
+            return null;
+        }
+
+        return remoteSnapshot;
     }
 
     private async Task BackfillRemoteProfileHash(
-        ProfileDto? originalProfile,
+        StorageProfileSnapshot? originalSnapshot,
         Profile downloadedProfile,
         CancellationToken cancellationToken)
     {
-        if (originalProfile is null)
+        if (originalSnapshot is null)
         {
             return;
         }
@@ -91,14 +99,16 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
         {
             var currentSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
             if (currentSnapshot is null ||
-                !CanBackfillRemoteProfileHash(originalProfile, currentSnapshot.Profile))
+                !string.Equals(currentSnapshot.Version, originalSnapshot.Version, StringComparison.Ordinal) ||
+                !CanBackfillRemoteProfileHash(originalSnapshot.Profile, currentSnapshot.Profile))
             {
                 _logger.Write("[PULL] Remote profile does not meet hash backfill preconditions, skipped metadata update.");
                 return;
             }
 
             var calculatedHash = await downloadedProfile.GetHash(cancellationToken);
-            if (string.IsNullOrEmpty(calculatedHash))
+            if (string.IsNullOrEmpty(calculatedHash) ||
+                FileProfile.IsOversizedFileHash(calculatedHash))
             {
                 return;
             }
@@ -130,6 +140,18 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             currentProfile.HasData == originalProfile.HasData &&
             string.Equals(currentProfile.DataName, originalProfile.DataName, StringComparison.Ordinal) &&
             currentProfile.Size == originalProfile.Size;
+    }
+
+    private static bool MatchesNormalizedFileProfile(ProfileDto normalizedProfile, ProfileDto remoteProfile)
+    {
+        var typeMatches = remoteProfile.Type == normalizedProfile.Type ||
+            remoteProfile.Type == ProfileType.File && normalizedProfile.Type == ProfileType.Image;
+        return typeMatches &&
+            string.IsNullOrEmpty(remoteProfile.Hash) &&
+            string.Equals(remoteProfile.Text, normalizedProfile.Text, StringComparison.Ordinal) &&
+            remoteProfile.HasData == normalizedProfile.HasData &&
+            string.Equals(remoteProfile.DataName, normalizedProfile.DataName, StringComparison.Ordinal) &&
+            remoteProfile.Size == normalizedProfile.Size;
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -152,19 +152,56 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
 
     private static bool MatchesKnownProfileMetadata(ProfileDto downloadedProfile, ProfileDto currentProfile)
     {
-        return (string.IsNullOrEmpty(currentProfile.Hash) ||
-                string.Equals(currentProfile.Hash, downloadedProfile.Hash, StringComparison.OrdinalIgnoreCase)) &&
-            (currentProfile.Size is null || currentProfile.Size == downloadedProfile.Size);
+        if (!string.IsNullOrEmpty(currentProfile.Hash))
+        {
+            if (!string.Equals(currentProfile.Hash, downloadedProfile.Hash, StringComparison.OrdinalIgnoreCase))
+            {
+                return false;
+            }
+        }
+
+        if (currentProfile.Size is not null)
+        {
+            if (currentProfile.Size != downloadedProfile.Size)
+            {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private static bool MatchesProfileIdentity(ProfileDto downloadedProfile, ProfileDto currentProfile)
     {
-        var typeMatches = currentProfile.Type == downloadedProfile.Type ||
-            (currentProfile.Type == ProfileType.File && downloadedProfile.Type == ProfileType.Image);
-        return typeMatches &&
-            string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal) &&
-            currentProfile.HasData == downloadedProfile.HasData &&
-            string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal);
+        if (currentProfile.Type != downloadedProfile.Type)
+        {
+            if (currentProfile.Type != ProfileType.File)
+            {
+                return false;
+            }
+
+            if (downloadedProfile.Type != ProfileType.Image)
+            {
+                return false;
+            }
+        }
+
+        if (!string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (currentProfile.HasData != downloadedProfile.HasData)
+        {
+            return false;
+        }
+
+        if (!string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -34,7 +34,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
 
     public async Task DownloadProfileDataAsync(Profile profile, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
-        var shouldBackfillHash = string.IsNullOrEmpty(await profile.GetHash(cancellationToken));
+        var shouldFillBack = await IsProfileDtoMetadataIncompleteAsync(profile, cancellationToken);
         var persistentDir = _profileEnv.GetPersistentDir();
         var dataPath = await profile.NeedsTransferData(persistentDir, cancellationToken);
         if (dataPath is null)
@@ -47,9 +47,9 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
             var fileName = Path.GetFileName(dataPath);
             await _serverAdapter.DownloadFileAsync(fileName, dataPath, progress, cancellationToken);
             await profile.SetAndMoveTransferData(persistentDir, dataPath, cancellationToken);
-            if (shouldBackfillHash)
+            if (shouldFillBack)
             {
-                await BackfillRemoteProfileHash(profile, cancellationToken);
+                await FillBackRemoteProfile(profile, cancellationToken);
             }
             _logger.Write($"[PULL] Downloaded {fileName} to {dataPath}");
             _trayIcon.SetStatusString(ServerConstants.StatusName, "Running.");
@@ -67,7 +67,15 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
         }
     }
 
-    private async Task BackfillRemoteProfileHash(
+    private static async Task<bool> IsProfileDtoMetadataIncompleteAsync(
+        Profile profile,
+        CancellationToken cancellationToken)
+    {
+        return string.IsNullOrEmpty(await profile.GetHash(cancellationToken)) ||
+            !profile.HasKnownSize;
+    }
+
+    private async Task FillBackRemoteProfile(
         Profile downloadedProfile,
         CancellationToken cancellationToken)
     {
@@ -86,17 +94,21 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
 
             var currentSnapshot = await storageBasedServerAdapter.GetProfileSnapshotAsync(cancellationToken);
             if (currentSnapshot is null ||
-                !CanBackfillRemoteProfileHash(downloadedProfileDto, currentSnapshot.Profile))
+                !ShouldFillBack(downloadedProfileDto, currentSnapshot.Profile))
             {
-                _logger.Write("[PULL] Remote profile does not meet hash backfill preconditions, skipped metadata update.");
+                _logger.Write("[PULL] Remote profile does not meet metadata fill-back preconditions, skipped metadata update.");
                 return;
             }
 
-            var updatedProfile = currentSnapshot.Profile with { Hash = downloadedProfileDto.Hash };
+            var updatedProfile = currentSnapshot.Profile with
+            {
+                Hash = downloadedProfileDto.Hash,
+                Size = downloadedProfileDto.Size,
+            };
             if (string.IsNullOrWhiteSpace(currentSnapshot.Version))
             {
                 await _serverAdapter.SetProfileAsync(updatedProfile, cancellationToken);
-                _logger.Write($"[PULL] Backfilled remote profile hash without version precondition: {downloadedProfileDto.Hash}");
+                _logger.Write($"[PULL] Filled back remote profile metadata without version precondition: {downloadedProfileDto.Hash}");
                 return;
             }
 
@@ -110,7 +122,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
                 return;
             }
 
-            _logger.Write($"[PULL] Backfilled remote profile hash: {downloadedProfileDto.Hash}");
+            _logger.Write($"[PULL] Filled back remote profile metadata: {downloadedProfileDto.Hash}");
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
@@ -118,16 +130,48 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serv
         }
     }
 
-    private static bool CanBackfillRemoteProfileHash(ProfileDto downloadedProfile, ProfileDto currentProfile)
+    private static bool ShouldFillBack(ProfileDto downloadedProfile, ProfileDto currentProfile)
     {
-        var typeMatches = currentProfile.Type == downloadedProfile.Type ||
-            (currentProfile.Type == ProfileType.File && downloadedProfile.Type == ProfileType.Image);
-        return typeMatches &&
-            string.IsNullOrEmpty(currentProfile.Hash) &&
-            string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal) &&
-            currentProfile.HasData == downloadedProfile.HasData &&
-            string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal) &&
-            currentProfile.Size == downloadedProfile.Size;
+        var shouldFillHash = string.IsNullOrEmpty(currentProfile.Hash);
+        var shouldFillSize = currentProfile.Size is null;
+        if (!shouldFillHash && !shouldFillSize)
+        {
+            return false;
+        }
+
+        if (!shouldFillHash &&
+            !string.Equals(currentProfile.Hash, downloadedProfile.Hash, StringComparison.OrdinalIgnoreCase))
+        {
+            return false;
+        }
+
+        if (currentProfile.Type != downloadedProfile.Type &&
+            (currentProfile.Type != ProfileType.File || downloadedProfile.Type != ProfileType.Image))
+        {
+            return false;
+        }
+
+        if (!string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (currentProfile.HasData != downloadedProfile.HasData)
+        {
+            return false;
+        }
+
+        if (!string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal))
+        {
+            return false;
+        }
+
+        if (!shouldFillSize && currentProfile.Size != downloadedProfile.Size)
+        {
+            return false;
+        }
+
+        return true;
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -34,6 +34,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
 
     public async Task DownloadProfileDataAsync(Profile profile, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
+        var remoteProfileWithoutHash = await GetRemoteFileProfileWithoutHash(profile, cancellationToken);
         var persistentDir = _profileEnv.GetPersistentDir();
         var dataPath = await profile.NeedsTransferData(persistentDir, cancellationToken);
         if (dataPath is null)
@@ -46,6 +47,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             var fileName = Path.GetFileName(dataPath);
             await _serverAdapter.DownloadFileAsync(fileName, dataPath, progress, cancellationToken);
             await profile.SetAndMoveTransferData(persistentDir, dataPath, cancellationToken);
+            await BackfillRemoteProfileHash(remoteProfileWithoutHash, profile, cancellationToken);
             _logger.Write($"[PULL] Downloaded {fileName} to {dataPath}");
             _trayIcon.SetStatusString(ServerConstants.StatusName, "Running.");
         }
@@ -60,6 +62,66 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             SetErrorStatus("Failed to download profile data", ex);
             throw new ProfileDataDownloadException("Failed to download profile data", ex);
         }
+    }
+
+    private static async Task<ProfileDto?> GetRemoteFileProfileWithoutHash(
+        Profile profile,
+        CancellationToken cancellationToken)
+    {
+        if (profile is not FileProfile ||
+            !string.IsNullOrEmpty(await profile.GetHash(cancellationToken)))
+        {
+            return null;
+        }
+
+        return await profile.ToProfileDto(cancellationToken);
+    }
+
+    private async Task BackfillRemoteProfileHash(
+        ProfileDto? originalProfile,
+        Profile downloadedProfile,
+        CancellationToken cancellationToken)
+    {
+        if (originalProfile is null)
+        {
+            return;
+        }
+
+        try
+        {
+            var currentProfile = await _serverAdapter.GetProfileAsync(cancellationToken);
+            if (!CanBackfillRemoteProfileHash(originalProfile, currentProfile))
+            {
+                _logger.Write("[PULL] Remote profile changed before hash backfill, skipped metadata update.");
+                return;
+            }
+
+            var calculatedHash = await downloadedProfile.GetHash(cancellationToken);
+            if (string.IsNullOrEmpty(calculatedHash))
+            {
+                return;
+            }
+
+            await _serverAdapter.SetProfileAsync(
+                currentProfile! with { Hash = calculatedHash },
+                cancellationToken);
+            _logger.Write($"[PULL] Backfilled remote profile hash: {calculatedHash}");
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.Write($"[PULL] Failed to backfill remote profile hash: {ex.Message}");
+        }
+    }
+
+    private static bool CanBackfillRemoteProfileHash(ProfileDto originalProfile, ProfileDto? currentProfile)
+    {
+        return currentProfile is not null &&
+            string.IsNullOrEmpty(currentProfile.Hash) &&
+            currentProfile.Type == originalProfile.Type &&
+            string.Equals(currentProfile.Text, originalProfile.Text, StringComparison.Ordinal) &&
+            currentProfile.HasData == originalProfile.HasData &&
+            string.Equals(currentProfile.DataName, originalProfile.DataName, StringComparison.Ordinal) &&
+            currentProfile.Size == originalProfile.Size;
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -11,9 +11,9 @@ using System.Text.Json;
 
 namespace SyncClipboard.Core.RemoteServer;
 
-internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServerAdapter serverAdapter)
+internal class StorageBasedServerHelper(IServiceProvider sp, IServerAdapter serverAdapter)
 {
-    private readonly IStorageBasedServerAdapter _serverAdapter = serverAdapter;
+    private readonly IServerAdapter _serverAdapter = serverAdapter;
     private readonly ILogger _logger = sp.GetRequiredService<ILogger>();
     private readonly ITrayIcon _trayIcon = sp.GetRequiredService<ITrayIcon>();
     private readonly IProfileEnv _profileEnv = sp.GetRequiredService<IProfileEnv>();
@@ -34,7 +34,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
 
     public async Task DownloadProfileDataAsync(Profile profile, IProgress<HttpDownloadProgress>? progress = null, CancellationToken cancellationToken = default)
     {
-        var remoteSnapshotWithoutHash = await GetRemoteFileProfileWithoutHash(profile, cancellationToken);
+        var shouldBackfillHash = string.IsNullOrEmpty(await profile.GetHash(cancellationToken));
         var persistentDir = _profileEnv.GetPersistentDir();
         var dataPath = await profile.NeedsTransferData(persistentDir, cancellationToken);
         if (dataPath is null)
@@ -47,7 +47,10 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             var fileName = Path.GetFileName(dataPath);
             await _serverAdapter.DownloadFileAsync(fileName, dataPath, progress, cancellationToken);
             await profile.SetAndMoveTransferData(persistentDir, dataPath, cancellationToken);
-            await BackfillRemoteProfileHash(remoteSnapshotWithoutHash, profile, cancellationToken);
+            if (shouldBackfillHash)
+            {
+                await BackfillRemoteProfileHash(profile, cancellationToken);
+            }
             _logger.Write($"[PULL] Downloaded {fileName} to {dataPath}");
             _trayIcon.SetStatusString(ServerConstants.StatusName, "Running.");
         }
@@ -64,65 +67,41 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
         }
     }
 
-    private async Task<StorageProfileSnapshot?> GetRemoteFileProfileWithoutHash(
-        Profile profile,
-        CancellationToken cancellationToken)
-    {
-        if (profile is not FileProfile ||
-            !string.IsNullOrEmpty(await profile.GetHash(cancellationToken)))
-        {
-            return null;
-        }
-
-        try
-        {
-            var normalizedProfile = await profile.ToProfileDto(cancellationToken);
-            var remoteSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
-            if (remoteSnapshot is null ||
-                !MatchesNormalizedFileProfile(normalizedProfile, remoteSnapshot.Profile))
-            {
-                return null;
-            }
-
-            return remoteSnapshot;
-        }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-        {
-            _logger.Write($"[PULL] Failed to capture remote profile for optional hash backfill: {ex}");
-            return null;
-        }
-    }
-
     private async Task BackfillRemoteProfileHash(
-        StorageProfileSnapshot? originalSnapshot,
         Profile downloadedProfile,
         CancellationToken cancellationToken)
     {
-        if (originalSnapshot is null)
+        if (_serverAdapter is not IStorageBasedServerAdapter storageBasedServerAdapter)
         {
             return;
         }
 
         try
         {
-            var currentSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
+            var downloadedProfileDto = await downloadedProfile.ToProfileDto(cancellationToken);
+            if (string.IsNullOrEmpty(downloadedProfileDto.Hash))
+            {
+                return;
+            }
+
+            var currentSnapshot = await storageBasedServerAdapter.GetProfileSnapshotAsync(cancellationToken);
             if (currentSnapshot is null ||
-                !string.Equals(currentSnapshot.Version, originalSnapshot.Version, StringComparison.Ordinal) ||
-                !CanBackfillRemoteProfileHash(originalSnapshot.Profile, currentSnapshot.Profile))
+                !CanBackfillRemoteProfileHash(downloadedProfileDto, currentSnapshot.Profile))
             {
                 _logger.Write("[PULL] Remote profile does not meet hash backfill preconditions, skipped metadata update.");
                 return;
             }
 
-            var calculatedHash = await downloadedProfile.GetHash(cancellationToken);
-            if (string.IsNullOrEmpty(calculatedHash) ||
-                FileProfile.IsOversizedFileHash(calculatedHash))
+            var updatedProfile = currentSnapshot.Profile with { Hash = downloadedProfileDto.Hash };
+            if (string.IsNullOrWhiteSpace(currentSnapshot.Version))
             {
+                await _serverAdapter.SetProfileAsync(updatedProfile, cancellationToken);
+                _logger.Write($"[PULL] Backfilled remote profile hash without version precondition: {downloadedProfileDto.Hash}");
                 return;
             }
 
-            var updated = await _serverAdapter.TrySetProfileAsync(
-                currentSnapshot.Profile with { Hash = calculatedHash },
+            var updated = await storageBasedServerAdapter.TrySetProfileAsync(
+                updatedProfile,
                 currentSnapshot.Version,
                 cancellationToken);
             if (!updated)
@@ -131,7 +110,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
                 return;
             }
 
-            _logger.Write($"[PULL] Backfilled remote profile hash: {calculatedHash}");
+            _logger.Write($"[PULL] Backfilled remote profile hash: {downloadedProfileDto.Hash}");
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
@@ -139,27 +118,16 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
         }
     }
 
-    private static bool CanBackfillRemoteProfileHash(ProfileDto originalProfile, ProfileDto? currentProfile)
+    private static bool CanBackfillRemoteProfileHash(ProfileDto downloadedProfile, ProfileDto currentProfile)
     {
-        return currentProfile is not null &&
-            string.IsNullOrEmpty(currentProfile.Hash) &&
-            currentProfile.Type == originalProfile.Type &&
-            string.Equals(currentProfile.Text, originalProfile.Text, StringComparison.Ordinal) &&
-            currentProfile.HasData == originalProfile.HasData &&
-            string.Equals(currentProfile.DataName, originalProfile.DataName, StringComparison.Ordinal) &&
-            currentProfile.Size == originalProfile.Size;
-    }
-
-    private static bool MatchesNormalizedFileProfile(ProfileDto normalizedProfile, ProfileDto remoteProfile)
-    {
-        var typeMatches = remoteProfile.Type == normalizedProfile.Type ||
-            (remoteProfile.Type == ProfileType.File && normalizedProfile.Type == ProfileType.Image);
+        var typeMatches = currentProfile.Type == downloadedProfile.Type ||
+            (currentProfile.Type == ProfileType.File && downloadedProfile.Type == ProfileType.Image);
         return typeMatches &&
-            string.IsNullOrEmpty(remoteProfile.Hash) &&
-            string.Equals(remoteProfile.Text, normalizedProfile.Text, StringComparison.Ordinal) &&
-            remoteProfile.HasData == normalizedProfile.HasData &&
-            string.Equals(remoteProfile.DataName, normalizedProfile.DataName, StringComparison.Ordinal) &&
-            remoteProfile.Size == normalizedProfile.Size;
+            string.IsNullOrEmpty(currentProfile.Hash) &&
+            string.Equals(currentProfile.Text, downloadedProfile.Text, StringComparison.Ordinal) &&
+            currentProfile.HasData == downloadedProfile.HasData &&
+            string.Equals(currentProfile.DataName, downloadedProfile.DataName, StringComparison.Ordinal) &&
+            currentProfile.Size == downloadedProfile.Size;
     }
 
     public void SetErrorStatus(string message, Exception? innerException = null)

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -74,15 +74,23 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
             return null;
         }
 
-        var normalizedProfile = await profile.ToProfileDto(cancellationToken);
-        var remoteSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
-        if (remoteSnapshot is null ||
-            !MatchesNormalizedFileProfile(normalizedProfile, remoteSnapshot.Profile))
+        try
         {
+            var normalizedProfile = await profile.ToProfileDto(cancellationToken);
+            var remoteSnapshot = await _serverAdapter.GetProfileSnapshotAsync(cancellationToken);
+            if (remoteSnapshot is null ||
+                !MatchesNormalizedFileProfile(normalizedProfile, remoteSnapshot.Profile))
+            {
+                return null;
+            }
+
+            return remoteSnapshot;
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            _logger.Write($"[PULL] Failed to capture remote profile for optional hash backfill: {ex}");
             return null;
         }
-
-        return remoteSnapshot;
     }
 
     private async Task BackfillRemoteProfileHash(

--- a/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
+++ b/src/SyncClipboard.Core/RemoteServer/StorageBasedServerHelper.cs
@@ -153,7 +153,7 @@ internal class StorageBasedServerHelper(IServiceProvider sp, IStorageBasedServer
     private static bool MatchesNormalizedFileProfile(ProfileDto normalizedProfile, ProfileDto remoteProfile)
     {
         var typeMatches = remoteProfile.Type == normalizedProfile.Type ||
-            remoteProfile.Type == ProfileType.File && normalizedProfile.Type == ProfileType.Image;
+            (remoteProfile.Type == ProfileType.File && normalizedProfile.Type == ProfileType.Image);
         return typeMatches &&
             string.IsNullOrEmpty(remoteProfile.Hash) &&
             string.Equals(remoteProfile.Text, normalizedProfile.Text, StringComparison.Ordinal) &&

--- a/src/SyncClipboard.Core/Utilities/Web/WebDavBase.cs
+++ b/src/SyncClipboard.Core/Utilities/Web/WebDavBase.cs
@@ -174,6 +174,19 @@ namespace SyncClipboard.Core.Utilities.Web
             );
         }
 
+        public async Task<(Type? Value, string? Version)> GetJsonWithVersion<Type>(
+            string url,
+            CancellationToken? cancelToken = null)
+        {
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var response = await HttpClient.GetAsync(url, cancellationSource.Token);
+            response.EnsureSuccessStatusCode();
+            var value = await response.Content.ReadFromJsonAsync<Type>(
+                SerializerOptions,
+                cancellationSource.Token);
+            return (value, response.Headers.ETag?.ToString());
+        }
+
         public async Task PutJson<Type>(string url, Type jsonContent, CancellationToken? cancelToken = null)
         {
             using var cancellationSource = CreateRequestCancellationSource(cancelToken);
@@ -184,6 +197,32 @@ namespace SyncClipboard.Core.Utilities.Web
                 content,
                 cancellationSource.Token
             );
+        }
+
+        public async Task<bool> PutJsonIfVersion<Type>(
+            string url,
+            Type jsonContent,
+            string? expectedVersion,
+            CancellationToken? cancelToken = null)
+        {
+            if (string.IsNullOrWhiteSpace(expectedVersion))
+            {
+                return false;
+            }
+
+            using var cancellationSource = CreateRequestCancellationSource(cancelToken);
+            using var request = new HttpRequestMessage(HttpMethod.Put, url);
+            request.Headers.TryAddWithoutValidation("If-Match", expectedVersion);
+            request.Content = JsonContent.Create(jsonContent, null, SerializerOptions);
+            await request.Content.LoadIntoBufferAsync(); // avoid chunked encoding
+            using var response = await HttpClient.SendAsync(request, cancellationSource.Token);
+            if (response.StatusCode is HttpStatusCode.PreconditionFailed or HttpStatusCode.Conflict)
+            {
+                return false;
+            }
+
+            response.EnsureSuccessStatusCode();
+            return true;
         }
 
         private CancellationTokenSource CreateRequestCancellationSource(CancellationToken? cancelToken = null)

--- a/src/SyncClipboard.Shared/ProfileDto.cs
+++ b/src/SyncClipboard.Shared/ProfileDto.cs
@@ -11,5 +11,6 @@ public record class ProfileDto
     public string Text { get; set; } = string.Empty;
     public bool HasData { get; set; } = false;
     public string? DataName { get; set; }
-    public long Size { get; set; } = 0;
+    [JsonIgnore(Condition = JsonIgnoreCondition.WhenWritingNull)]
+    public long? Size { get; set; }
 }

--- a/src/SyncClipboard.Shared/Profiles/FileProfile.cs
+++ b/src/SyncClipboard.Shared/Profiles/FileProfile.cs
@@ -5,8 +5,6 @@ namespace SyncClipboard.Shared.Profiles;
 
 public class FileProfile : Profile
 {
-    protected const long MAX_FILE_SIZE = int.MaxValue;
-
     public virtual string FileName { get; set; } = "";
     public override string DisplayText => FileName;
 
@@ -14,13 +12,6 @@ public class FileProfile : Profile
     public override ProfileType Type => ProfileType.File;
     public virtual string? FullPath { get; set; }
     public override bool HasTransferData => true;
-
-    protected const string HASH_FOR_OVERSIZED_FILE = "HASH_FOR_OVERSIZED_FILE";
-
-    public static bool IsOversizedFileHash(string? hash)
-    {
-        return string.Equals(hash, HASH_FOR_OVERSIZED_FILE, StringComparison.Ordinal);
-    }
 
     public FileProfile(ProfilePersistentInfo entity)
     {
@@ -105,12 +96,6 @@ public class FileProfile : Profile
     protected async static Task<string> GetSHA256HashFromFile(string filePath, CancellationToken? cancelToken)
     {
         cancelToken ??= CancellationToken.None;
-        var fileInfo = new FileInfo(filePath);
-        if (fileInfo.Length > MAX_FILE_SIZE)
-        {
-            return HASH_FOR_OVERSIZED_FILE;
-        }
-
         var contentSha256Hex = await Utility.CalculateFileSHA256(filePath, cancelToken.Value);
         var fileName = Path.GetFileName(filePath);
         var hash = await CombineHash(fileName, contentSha256Hex, cancelToken.Value);

--- a/src/SyncClipboard.Shared/Profiles/FileProfile.cs
+++ b/src/SyncClipboard.Shared/Profiles/FileProfile.cs
@@ -17,6 +17,11 @@ public class FileProfile : Profile
 
     protected const string HASH_FOR_OVERSIZED_FILE = "HASH_FOR_OVERSIZED_FILE";
 
+    public static bool IsOversizedFileHash(string? hash)
+    {
+        return string.Equals(hash, HASH_FOR_OVERSIZED_FILE, StringComparison.Ordinal);
+    }
+
     public FileProfile(ProfilePersistentInfo entity)
     {
         if (entity.FilePaths.Length > 0)

--- a/src/SyncClipboard.Shared/Profiles/GroupProfile.cs
+++ b/src/SyncClipboard.Shared/Profiles/GroupProfile.cs
@@ -79,7 +79,12 @@ public class GroupProfile : Profile
 
     protected override async Task ComputeHash(CancellationToken token)
     {
-        var (hash, size) = await Task.Run(() => CaclHashAndSize(_files ?? [], token), token).WaitAsync(token);
+        if (_files is null || _files.Length == 0)
+        {
+            return;
+        }
+
+        var (hash, size) = await Task.Run(() => CaclHashAndSize(_files, token), token).WaitAsync(token);
         Hash = hash;
         Size ??= size;
     }

--- a/src/SyncClipboard.Shared/Profiles/Profile.cs
+++ b/src/SyncClipboard.Shared/Profiles/Profile.cs
@@ -17,6 +17,7 @@ public abstract class Profile
     public abstract Task<ProfileDto> ToProfileDto(CancellationToken token);
     protected abstract Task ComputeHash(CancellationToken token);
     protected abstract Task ComputeSize(CancellationToken token);
+    public bool HasKnownSize => Size is not null;
 
     public async ValueTask<long> GetSize(CancellationToken token)
     {

--- a/src/SyncClipboard.Shared/Profiles/TextProfile.cs
+++ b/src/SyncClipboard.Shared/Profiles/TextProfile.cs
@@ -304,15 +304,14 @@ public class TextProfile : Profile
 
     public override async Task SetTransferData(string path, bool verify, CancellationToken token)
     {
-        if (verify && File.Exists(path) && Hash is not null)
+        if (verify && File.Exists(path))
         {
             var fileHash = await Utility.CalculateFileSHA256(path, token);
-            var textHash = Hash;
-
-            if (!string.Equals(fileHash, textHash, StringComparison.OrdinalIgnoreCase))
+            if (Hash is not null && !string.Equals(fileHash, Hash, StringComparison.OrdinalIgnoreCase))
             {
                 throw new InvalidOperationException("Transfer data file content does not match the text hash.");
             }
+            Hash = fileHash;
         }
 
         _transferDataPath = path;

--- a/src/SyncClipboard.Test/ProfileDtoTests.cs
+++ b/src/SyncClipboard.Test/ProfileDtoTests.cs
@@ -1,0 +1,35 @@
+using SyncClipboard.Shared;
+using System.Text.Json;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class ProfileDtoTests
+{
+    [TestMethod]
+    public void Serialize_NullSizeOmitsProperty()
+    {
+        var json = JsonSerializer.Serialize(
+            new ProfileDto { Size = null },
+            JsonSerializerOptions.Web);
+
+        Assert.IsFalse(json.Contains("\"size\"", StringComparison.Ordinal));
+        var legacyDto = JsonSerializer.Deserialize<LegacyProfileDto>(json, JsonSerializerOptions.Web);
+        Assert.AreEqual(0, legacyDto?.Size);
+    }
+
+    [TestMethod]
+    public void Serialize_ZeroSizePreservesProperty()
+    {
+        var json = JsonSerializer.Serialize(
+            new ProfileDto { Size = 0 },
+            JsonSerializerOptions.Web);
+
+        Assert.Contains("\"size\":0", json);
+    }
+
+    private sealed class LegacyProfileDto
+    {
+        public long Size { get; set; }
+    }
+}

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -99,6 +99,47 @@ public class StorageBasedServerHelperTests
     }
 
     [TestMethod]
+    public async Task DownloadFileProfile_EmptyRemoteSizeBackfillsMetadata()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+            var expectedHash = await new FileProfile(remoteFile).GetHash(token);
+            var expectedSize = new FileInfo(remoteFile).Length;
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = expectedHash,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = null,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.SnapshotReadCount);
+            Assert.AreEqual(1, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.AreEqual(expectedHash, adapter.CurrentProfile?.Hash);
+            Assert.AreEqual(expectedSize, adapter.CurrentProfile?.Size);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [TestMethod]
     public async Task DownloadFileProfile_RemoteProfileChangedBeforeBackfillDoesNotOverwriteMetadata()
     {
         var token = TestContext.CancellationTokenSource.Token;

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -190,6 +190,85 @@ public class StorageBasedServerHelperTests
         }
     }
 
+    [TestMethod]
+    public async Task DownloadLegacyFileImageProfile_BackfillsOriginalWireType()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "image.png";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(testDirectory, adapter);
+            var profile = Profile.Create(remoteProfile);
+
+            Assert.IsInstanceOfType<ImageProfile>(profile);
+            await helper.DownloadProfileDataAsync(profile, cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.AreEqual(ProfileType.File, adapter.CurrentProfile?.Type);
+            Assert.IsFalse(string.IsNullOrEmpty(adapter.CurrentProfile?.Hash));
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadOversizedFileProfile_DoesNotBackfillSharedHashSentinel()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "oversized.bin";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1], token);
+            var oversizedLength = (long)int.MaxValue + 1;
+
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = oversizedLength,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile)
+            {
+                DownloadedFileLength = oversizedLength,
+            };
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(0, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(string.Empty, adapter.CurrentProfile?.Hash);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
     private static StorageBasedServerHelper CreateHelper(
         string persistentDirectory,
         IStorageBasedServerAdapter adapter)
@@ -225,6 +304,7 @@ public class StorageBasedServerHelperTests
         public ProfileDto? CurrentProfile { get; private set; } = currentProfile;
         public ProfileDto? ProfileAfterDownload { get; init; }
         public ProfileDto? ProfileBeforeConditionalSet { get; init; }
+        public long? DownloadedFileLength { get; init; }
         public int DownloadCount { get; private set; }
         public int UploadCount { get; private set; }
         public int SetProfileCount { get; private set; }
@@ -297,7 +377,15 @@ public class StorageBasedServerHelperTests
         {
             DownloadCount++;
             Directory.CreateDirectory(Path.GetDirectoryName(localPath)!);
-            File.Copy(remoteFile, localPath, overwrite: true);
+            if (DownloadedFileLength is not null)
+            {
+                using var stream = new FileStream(localPath, FileMode.Create, FileAccess.Write);
+                stream.SetLength(DownloadedFileLength.Value);
+            }
+            else
+            {
+                File.Copy(remoteFile, localPath, overwrite: true);
+            }
             if (ProfileAfterDownload is not null)
             {
                 CurrentProfile = ProfileAfterDownload;

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -1,0 +1,248 @@
+using Microsoft.Extensions.DependencyInjection;
+using SyncClipboard.Core.Interfaces;
+using SyncClipboard.Core.Models;
+using SyncClipboard.Core.Models.UserConfigs;
+using SyncClipboard.Core.RemoteServer;
+using SyncClipboard.Core.RemoteServer.Adapter;
+using SyncClipboard.Shared;
+using SyncClipboard.Shared.Profiles;
+using System.Net;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class StorageBasedServerHelperTests
+{
+    public TestContext TestContext { get; set; } = null!;
+
+    [TestMethod]
+    public async Task DownloadFileProfile_EmptyRemoteHashBackfillsMetadataWithoutUploadingFile()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(testDirectory, adapter);
+            var profile = Profile.Create(remoteProfile);
+
+            await helper.DownloadProfileDataAsync(profile, cancellationToken: token);
+
+            var expectedHash = await new FileProfile(remoteFile).GetHash(token);
+            Assert.AreEqual(1, adapter.DownloadCount);
+            Assert.AreEqual(0, adapter.UploadCount);
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.AreEqual(expectedHash, adapter.CurrentProfile?.Hash);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadFileProfile_RemoteProfileChangedBeforeBackfillDoesNotOverwriteMetadata()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var originalProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var newerProfile = new ProfileDto
+            {
+                Type = ProfileType.Text,
+                Hash = "NEW_REMOTE_HASH",
+                Text = "new clipboard",
+                HasData = false,
+                Size = "new clipboard".Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, originalProfile)
+            {
+                ProfileAfterDownload = newerProfile,
+            };
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(originalProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.DownloadCount);
+            Assert.AreEqual(0, adapter.SetProfileCount);
+            Assert.AreSame(newerProfile, adapter.CurrentProfile);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadFileProfile_ExistingRemoteHashDoesNotRewriteMetadata()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+            var expectedHash = await new FileProfile(remoteFile).GetHash(token);
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = expectedHash,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.DownloadCount);
+            Assert.AreEqual(0, adapter.SetProfileCount);
+            Assert.AreSame(remoteProfile, adapter.CurrentProfile);
+        }
+        finally
+        {
+            Directory.Delete(testDirectory, recursive: true);
+        }
+    }
+
+    private static StorageBasedServerHelper CreateHelper(
+        string persistentDirectory,
+        IStorageBasedServerAdapter adapter)
+    {
+        var services = new ServiceCollection();
+        services.AddSingleton<ILogger, TestLogger>();
+        services.AddSingleton<ITrayIcon, TestTrayIcon>();
+        services.AddSingleton<IProfileEnv>(new TestProfileEnv(persistentDirectory));
+        return new StorageBasedServerHelper(services.BuildServiceProvider(), adapter);
+    }
+
+    private static string CreateTestDirectory()
+    {
+        var path = Path.Combine(
+            Path.GetTempPath(),
+            $"SyncClipboard-StorageBasedServerHelperTests-{Guid.NewGuid():N}");
+        Directory.CreateDirectory(path);
+        return path;
+    }
+
+    private sealed class TestStorageAdapter(
+        string remoteFile,
+        ProfileDto currentProfile) : IStorageBasedServerAdapter
+    {
+        public ProfileDto? CurrentProfile { get; private set; } = currentProfile;
+        public ProfileDto? ProfileAfterDownload { get; init; }
+        public int DownloadCount { get; private set; }
+        public int UploadCount { get; private set; }
+        public int SetProfileCount { get; private set; }
+
+        public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+
+        public Task<ProfileDto?> GetProfileAsync(CancellationToken cancellationToken = default)
+        {
+            return Task.FromResult(CurrentProfile);
+        }
+
+        public Task SetProfileAsync(
+            ProfileDto profileDto,
+            CancellationToken cancellationToken = default)
+        {
+            SetProfileCount++;
+            CurrentProfile = profileDto;
+            return Task.CompletedTask;
+        }
+
+        public Task UploadFileAsync(
+            string fileName,
+            string localPath,
+            IProgress<HttpDownloadProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            UploadCount++;
+            return Task.CompletedTask;
+        }
+
+        public Task DownloadFileAsync(
+            string fileName,
+            string localPath,
+            IProgress<HttpDownloadProgress>? progress = null,
+            CancellationToken cancellationToken = default)
+        {
+            DownloadCount++;
+            Directory.CreateDirectory(Path.GetDirectoryName(localPath)!);
+            File.Copy(remoteFile, localPath, overwrite: true);
+            CurrentProfile = ProfileAfterDownload ?? CurrentProfile;
+            return Task.CompletedTask;
+        }
+
+        public Task CleanupTempFilesAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public Task TestConnectionAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
+        public void ApplyConfig() { }
+        public void SetConfig(object config, SyncConfig syncConfig) { }
+        public void SetProxy(IWebProxy proxy) { }
+    }
+
+    private sealed class TestProfileEnv(string persistentDirectory) : IProfileEnv
+    {
+        public string GetPersistentDir() => persistentDirectory;
+        public string GetHistoryPersistentDir() => persistentDirectory;
+    }
+
+    private sealed class TestLogger : ILogger
+    {
+        public void Write(string? tag, string str) { }
+        public void Write(string str) { }
+        public Task WriteAsync(string? tag, string str) => Task.CompletedTask;
+        public Task WriteAsync(string str) => Task.CompletedTask;
+        public void Flush() { }
+    }
+
+    private sealed class TestTrayIcon : ITrayIcon
+    {
+        public event Action? LeftClicked { add { } remove { } }
+        public event Action? DoubleClicked { add { } remove { } }
+
+        public void Create() { }
+        public void ShowUploadAnimation() { }
+        public void ShowDownloadAnimation() { }
+        public void StopAnimation() { }
+        public void SetStatusString(string key, string statusStr, bool error) { }
+        public void SetStatusString(string key, string statusStr) { }
+        public void SetActiveStatus(bool active) { }
+    }
+}

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -45,8 +45,52 @@ public class StorageBasedServerHelperTests
             var expectedHash = await new FileProfile(remoteFile).GetHash(token);
             Assert.AreEqual(1, adapter.DownloadCount);
             Assert.AreEqual(0, adapter.UploadCount);
+            Assert.AreEqual(1, adapter.SnapshotReadCount);
+            Assert.AreEqual(1, adapter.ConditionalSetAttemptCount);
             Assert.AreEqual(1, adapter.SetProfileCount);
             Assert.AreEqual(expectedHash, adapter.CurrentProfile?.Hash);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadFileProfile_MissingRemoteVersionBackfillsMetadataUnconditionally()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile)
+            {
+                OmitVersion = true,
+            };
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.SnapshotReadCount);
+            Assert.AreEqual(0, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.IsFalse(string.IsNullOrEmpty(adapter.CurrentProfile?.Hash));
         }
         finally
         {
@@ -132,6 +176,7 @@ public class StorageBasedServerHelperTests
                 cancellationToken: token);
 
             Assert.AreEqual(1, adapter.DownloadCount);
+            Assert.AreEqual(0, adapter.SnapshotReadCount);
             Assert.AreEqual(0, adapter.SetProfileCount);
             Assert.AreSame(remoteProfile, adapter.CurrentProfile);
         }
@@ -229,39 +274,61 @@ public class StorageBasedServerHelperTests
     }
 
     [TestMethod]
-    public async Task DownloadOversizedFileProfile_DoesNotBackfillSharedHashSentinel()
+    public async Task DownloadTransferredTextProfile_EmptyRemoteHashBackfillsMetadata()
     {
         var token = TestContext.CancellationTokenSource.Token;
         var testDirectory = CreateTestDirectory();
         try
         {
-            var fileName = "oversized.bin";
-            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
-            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
-            await File.WriteAllBytesAsync(remoteFile, [1], token);
-            var oversizedLength = (long)int.MaxValue + 1;
-
-            var remoteProfile = new ProfileDto
-            {
-                Type = ProfileType.File,
-                Hash = string.Empty,
-                Text = fileName,
-                HasData = true,
-                DataName = fileName,
-                Size = oversizedLength,
-            };
-            var adapter = new TestStorageAdapter(remoteFile, remoteProfile)
-            {
-                DownloadedFileLength = oversizedLength,
-            };
-            var helper = CreateHelper(testDirectory, adapter);
+            var sourceDirectory = Path.Combine(testDirectory, "source");
+            var sourceProfile = new TextProfile(new string('a', 10241));
+            var remoteFile = await sourceProfile.PrepareTransferData(sourceDirectory, token);
+            Assert.IsNotNull(remoteFile);
+            var remoteProfile = (await sourceProfile.ToProfileDto(token)) with { Hash = string.Empty };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(Path.Combine(testDirectory, "download"), adapter);
 
             await helper.DownloadProfileDataAsync(
                 Profile.Create(remoteProfile),
                 cancellationToken: token);
 
-            Assert.AreEqual(0, adapter.ConditionalSetAttemptCount);
-            Assert.AreEqual(string.Empty, adapter.CurrentProfile?.Hash);
+            Assert.AreEqual(1, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.IsFalse(string.IsNullOrEmpty(adapter.CurrentProfile?.Hash));
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadGroupProfile_EmptyRemoteHashBackfillsMetadata()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var sourceDirectory = Path.Combine(testDirectory, "source");
+            Directory.CreateDirectory(sourceDirectory);
+            var sourceFile = Path.Combine(sourceDirectory, "document.txt");
+            await File.WriteAllTextAsync(sourceFile, "group content", token);
+            var sourceProfile = new GroupProfile([sourceFile]);
+            var remoteFile = await sourceProfile.PrepareTransferData(
+                Path.Combine(testDirectory, "remote-cache"),
+                token);
+            Assert.IsNotNull(remoteFile);
+            var remoteProfile = (await sourceProfile.ToProfileDto(token)) with { Hash = string.Empty };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile);
+            var helper = CreateHelper(Path.Combine(testDirectory, "download"), adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(1, adapter.SetProfileCount);
+            Assert.IsFalse(string.IsNullOrEmpty(adapter.CurrentProfile?.Hash));
         }
         finally
         {
@@ -344,11 +411,12 @@ public class StorageBasedServerHelperTests
         public ProfileDto? CurrentProfile { get; private set; } = currentProfile;
         public ProfileDto? ProfileAfterDownload { get; init; }
         public ProfileDto? ProfileBeforeConditionalSet { get; init; }
-        public long? DownloadedFileLength { get; init; }
         public Exception? SnapshotException { get; init; }
+        public bool OmitVersion { get; init; }
         public int DownloadCount { get; private set; }
         public int UploadCount { get; private set; }
         public int SetProfileCount { get; private set; }
+        public int SnapshotReadCount { get; private set; }
         public int ConditionalSetAttemptCount { get; private set; }
         private int _profileVersion;
 
@@ -361,6 +429,7 @@ public class StorageBasedServerHelperTests
 
         public Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
         {
+            SnapshotReadCount++;
             if (SnapshotException is not null)
             {
                 throw SnapshotException;
@@ -368,7 +437,9 @@ public class StorageBasedServerHelperTests
 
             var snapshot = CurrentProfile is null
                 ? null
-                : new StorageProfileSnapshot(CurrentProfile, _profileVersion.ToString());
+                : new StorageProfileSnapshot(
+                    CurrentProfile,
+                    OmitVersion ? null : _profileVersion.ToString());
             return Task.FromResult(snapshot);
         }
 
@@ -423,15 +494,7 @@ public class StorageBasedServerHelperTests
         {
             DownloadCount++;
             Directory.CreateDirectory(Path.GetDirectoryName(localPath)!);
-            if (DownloadedFileLength is not null)
-            {
-                using var stream = new FileStream(localPath, FileMode.Create, FileAccess.Write);
-                stream.SetLength(DownloadedFileLength.Value);
-            }
-            else
-            {
-                File.Copy(remoteFile, localPath, overwrite: true);
-            }
+            File.Copy(remoteFile, localPath, overwrite: true);
             if (ProfileAfterDownload is not null)
             {
                 CurrentProfile = ProfileAfterDownload;

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -269,6 +269,46 @@ public class StorageBasedServerHelperTests
         }
     }
 
+    [TestMethod]
+    public async Task DownloadFileProfile_BackfillSnapshotFailureStillDownloadsFile()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var remoteProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, remoteProfile)
+            {
+                SnapshotException = new HttpRequestException("temporary failure"),
+            };
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(remoteProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.DownloadCount);
+            Assert.AreEqual(0, adapter.ConditionalSetAttemptCount);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
     private static StorageBasedServerHelper CreateHelper(
         string persistentDirectory,
         IStorageBasedServerAdapter adapter)
@@ -305,6 +345,7 @@ public class StorageBasedServerHelperTests
         public ProfileDto? ProfileAfterDownload { get; init; }
         public ProfileDto? ProfileBeforeConditionalSet { get; init; }
         public long? DownloadedFileLength { get; init; }
+        public Exception? SnapshotException { get; init; }
         public int DownloadCount { get; private set; }
         public int UploadCount { get; private set; }
         public int SetProfileCount { get; private set; }
@@ -320,6 +361,11 @@ public class StorageBasedServerHelperTests
 
         public Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
         {
+            if (SnapshotException is not null)
+            {
+                throw SnapshotException;
+            }
+
             var snapshot = CurrentProfile is null
                 ? null
                 : new StorageProfileSnapshot(CurrentProfile, _profileVersion.ToString());

--- a/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
+++ b/src/SyncClipboard.Test/StorageBasedServerHelperTests.cs
@@ -50,7 +50,7 @@ public class StorageBasedServerHelperTests
         }
         finally
         {
-            Directory.Delete(testDirectory, recursive: true);
+            DeleteTestDirectory(testDirectory);
         }
     }
 
@@ -99,7 +99,7 @@ public class StorageBasedServerHelperTests
         }
         finally
         {
-            Directory.Delete(testDirectory, recursive: true);
+            DeleteTestDirectory(testDirectory);
         }
     }
 
@@ -137,7 +137,56 @@ public class StorageBasedServerHelperTests
         }
         finally
         {
-            Directory.Delete(testDirectory, recursive: true);
+            DeleteTestDirectory(testDirectory);
+        }
+    }
+
+    [TestMethod]
+    public async Task DownloadFileProfile_RemoteProfileChangedDuringConditionalBackfillDoesNotOverwriteMetadata()
+    {
+        var token = TestContext.CancellationTokenSource.Token;
+        var testDirectory = CreateTestDirectory();
+        try
+        {
+            var fileName = "video.mov";
+            var remoteFile = Path.Combine(testDirectory, "remote", fileName);
+            Directory.CreateDirectory(Path.GetDirectoryName(remoteFile)!);
+            await File.WriteAllBytesAsync(remoteFile, [1, 2, 3, 4], token);
+
+            var originalProfile = new ProfileDto
+            {
+                Type = ProfileType.File,
+                Hash = string.Empty,
+                Text = fileName,
+                HasData = true,
+                DataName = fileName,
+                Size = new FileInfo(remoteFile).Length,
+            };
+            var newerProfile = new ProfileDto
+            {
+                Type = ProfileType.Text,
+                Hash = "NEW_REMOTE_HASH",
+                Text = "new clipboard",
+                HasData = false,
+                Size = "new clipboard".Length,
+            };
+            var adapter = new TestStorageAdapter(remoteFile, originalProfile)
+            {
+                ProfileBeforeConditionalSet = newerProfile,
+            };
+            var helper = CreateHelper(testDirectory, adapter);
+
+            await helper.DownloadProfileDataAsync(
+                Profile.Create(originalProfile),
+                cancellationToken: token);
+
+            Assert.AreEqual(1, adapter.ConditionalSetAttemptCount);
+            Assert.AreEqual(0, adapter.SetProfileCount);
+            Assert.AreSame(newerProfile, adapter.CurrentProfile);
+        }
+        finally
+        {
+            DeleteTestDirectory(testDirectory);
         }
     }
 
@@ -161,15 +210,26 @@ public class StorageBasedServerHelperTests
         return path;
     }
 
+    private static void DeleteTestDirectory(string path)
+    {
+        if (Directory.Exists(path))
+        {
+            Directory.Delete(path, recursive: true);
+        }
+    }
+
     private sealed class TestStorageAdapter(
         string remoteFile,
         ProfileDto currentProfile) : IStorageBasedServerAdapter
     {
         public ProfileDto? CurrentProfile { get; private set; } = currentProfile;
         public ProfileDto? ProfileAfterDownload { get; init; }
+        public ProfileDto? ProfileBeforeConditionalSet { get; init; }
         public int DownloadCount { get; private set; }
         public int UploadCount { get; private set; }
         public int SetProfileCount { get; private set; }
+        public int ConditionalSetAttemptCount { get; private set; }
+        private int _profileVersion;
 
         public Task InitializeAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
@@ -178,13 +238,45 @@ public class StorageBasedServerHelperTests
             return Task.FromResult(CurrentProfile);
         }
 
+        public Task<StorageProfileSnapshot?> GetProfileSnapshotAsync(CancellationToken cancellationToken = default)
+        {
+            var snapshot = CurrentProfile is null
+                ? null
+                : new StorageProfileSnapshot(CurrentProfile, _profileVersion.ToString());
+            return Task.FromResult(snapshot);
+        }
+
         public Task SetProfileAsync(
             ProfileDto profileDto,
             CancellationToken cancellationToken = default)
         {
             SetProfileCount++;
             CurrentProfile = profileDto;
+            _profileVersion++;
             return Task.CompletedTask;
+        }
+
+        public Task<bool> TrySetProfileAsync(
+            ProfileDto profileDto,
+            string? expectedVersion,
+            CancellationToken cancellationToken = default)
+        {
+            ConditionalSetAttemptCount++;
+            if (ProfileBeforeConditionalSet is not null)
+            {
+                CurrentProfile = ProfileBeforeConditionalSet;
+                _profileVersion++;
+            }
+
+            if (expectedVersion != _profileVersion.ToString())
+            {
+                return Task.FromResult(false);
+            }
+
+            SetProfileCount++;
+            CurrentProfile = profileDto;
+            _profileVersion++;
+            return Task.FromResult(true);
         }
 
         public Task UploadFileAsync(
@@ -206,7 +298,11 @@ public class StorageBasedServerHelperTests
             DownloadCount++;
             Directory.CreateDirectory(Path.GetDirectoryName(localPath)!);
             File.Copy(remoteFile, localPath, overwrite: true);
-            CurrentProfile = ProfileAfterDownload ?? CurrentProfile;
+            if (ProfileAfterDownload is not null)
+            {
+                CurrentProfile = ProfileAfterDownload;
+                _profileVersion++;
+            }
             return Task.CompletedTask;
         }
 

--- a/src/SyncClipboard.Test/WebDavBaseTest.cs
+++ b/src/SyncClipboard.Test/WebDavBaseTest.cs
@@ -1,6 +1,7 @@
 using SyncClipboard.Core.Interfaces;
 using SyncClipboard.Core.Utilities.Web;
 using System.Net;
+using System.Net.Http.Headers;
 
 namespace SyncClipboard.Test;
 
@@ -55,6 +56,51 @@ public class WebDavBaseTest
         Assert.ThrowsExactly<ObjectDisposedException>(() => _ = handler.CapturedToken.WaitHandle);
     }
 
+    [TestMethod]
+    public async Task GetJsonWithVersionReturnsResponseETag()
+    {
+        using var handler = new DelegateHandler(_ =>
+        {
+            var response = new HttpResponseMessage(HttpStatusCode.OK)
+            {
+                Content = new StringContent("{\"value\":\"ok\"}")
+            };
+            response.Headers.ETag = new EntityTagHeaderValue("\"version-1\"");
+            return response;
+        });
+        using var webDav = new TestWebDav(handler);
+
+        var (payload, version) = await webDav.GetJsonWithVersion<TestPayload>(
+            "test",
+            TestContext.CancellationTokenSource.Token);
+
+        Assert.AreEqual("ok", payload?.Value);
+        Assert.AreEqual("\"version-1\"", version);
+    }
+
+    [TestMethod]
+    public async Task PutJsonIfVersionUsesIfMatchAndReportsPreconditionFailure()
+    {
+        string? ifMatch = null;
+        using var handler = new DelegateHandler(request =>
+        {
+            ifMatch = request.Headers.TryGetValues("If-Match", out var values)
+                ? values.Single()
+                : null;
+            return new HttpResponseMessage(HttpStatusCode.PreconditionFailed);
+        });
+        using var webDav = new TestWebDav(handler);
+
+        var updated = await webDav.PutJsonIfVersion(
+            "test",
+            new TestPayload("new"),
+            "\"version-1\"",
+            TestContext.CancellationTokenSource.Token);
+
+        Assert.IsFalse(updated);
+        Assert.AreEqual("\"version-1\"", ifMatch);
+    }
+
     private sealed class RecordingHandler(TaskCompletionSource? started = null) : HttpMessageHandler
     {
         public CancellationToken CapturedToken { get; private set; }
@@ -72,6 +118,17 @@ public class WebDavBaseTest
             {
                 Content = new StringContent("ok")
             };
+        }
+    }
+
+    private sealed class DelegateHandler(
+        Func<HttpRequestMessage, HttpResponseMessage> send) : HttpMessageHandler
+    {
+        protected override Task<HttpResponseMessage> SendAsync(
+            HttpRequestMessage request,
+            CancellationToken cancellationToken)
+        {
+            return Task.FromResult(send(request));
         }
     }
 
@@ -100,4 +157,6 @@ public class WebDavBaseTest
         public string UpdateApiUrl => string.Empty;
         public string UpdateUrl => string.Empty;
     }
+
+    private sealed record TestPayload(string Value);
 }


### PR DESCRIPTION
## 问题

WebDAV / S3 等存储型服务返回的文件元数据可能缺少 `hash`。客户端下载文件后会计算出真实哈希，但如果该文件超过本地上传大小限制，剪贴板回写会被过滤，远端元数据便始终保持空哈希，轮询时持续被判定为新内容并重复下载。

## 修复

- 在 `StorageBasedServerHelper` 下载文件成功后，用本地文件反推哈希并回填远端元数据
- 回填前重新读取远端元数据，仅在它仍是同一条且哈希为空时写入，避免覆盖并发更新
- 只更新 `SyncClipboard.json`，不会重新上传数据文件
- 回填失败不影响已经完成的下载
- 该逻辑仅位于存储型服务路径，不影响 Official Server

Closes #414