### PR TITLE
feat(server): add optional FCM profile change notifications

### DIFF
--- a/src/Directory.Packages.props
+++ b/src/Directory.Packages.props
@@ -28,6 +28,7 @@
     <PackageVersion Include="Microsoft.EntityFrameworkCore" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Sqlite" Version="9.0.8" />
     <PackageVersion Include="Microsoft.EntityFrameworkCore.Design" Version="9.0.8" />
+    <PackageVersion Include="FirebaseAdmin" Version="3.6.0" />
   </ItemGroup>
   <ItemGroup>
     <PackageVersion Include="Avalonia" Version="11.3.18" />

--- a/src/SyncClipboard.Server.Core/Controllers/CapabilitiesController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/CapabilitiesController.cs
@@ -1,6 +1,7 @@
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
 using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
 
 namespace SyncClipboard.Server.Core.Controllers;
 
@@ -8,17 +9,15 @@ namespace SyncClipboard.Server.Core.Controllers;
 [Route("api/capabilities")]
 [Authorize]
 [Tags("SyncClipboard")]
-public class CapabilitiesController : ControllerBase
+public class CapabilitiesController(IFcmPushClient fcmClient) : ControllerBase
 {
-    private static readonly RealtimeCapabilitiesDto CurrentCapabilities = new()
-    {
-        SignalR = true,
-        Push = new PushCapabilitiesDto { Fcm = false }
-    };
-
     [HttpGet]
     public ActionResult<RealtimeCapabilitiesDto> Get()
     {
-        return Ok(CurrentCapabilities);
+        return Ok(new RealtimeCapabilitiesDto
+        {
+            SignalR = true,
+            Push = new PushCapabilitiesDto { Fcm = fcmClient.IsAvailable }
+        });
     }
 }

--- a/src/SyncClipboard.Server.Core/Controllers/CapabilitiesController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/CapabilitiesController.cs
@@ -1,0 +1,24 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SyncClipboard.Server.Core.Models;
+
+namespace SyncClipboard.Server.Core.Controllers;
+
+[ApiController]
+[Route("api/capabilities")]
+[Authorize]
+[Tags("SyncClipboard")]
+public class CapabilitiesController : ControllerBase
+{
+    private static readonly RealtimeCapabilitiesDto CurrentCapabilities = new()
+    {
+        SignalR = true,
+        Push = new PushCapabilitiesDto { Fcm = false }
+    };
+
+    [HttpGet]
+    public ActionResult<RealtimeCapabilitiesDto> Get()
+    {
+        return Ok(CurrentCapabilities);
+    }
+}

--- a/src/SyncClipboard.Server.Core/Controllers/PushDevicesController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/PushDevicesController.cs
@@ -1,0 +1,94 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Server.Core.Controllers;
+
+[ApiController]
+[Route("api/devices/{deviceId}/push")]
+[Authorize]
+[Tags("SyncClipboard")]
+public class PushDevicesController(IPushDeviceRegistry registry) : ControllerBase
+{
+    private const string ANDROID_PLATFORM = "android";
+    private const string FCM_PROVIDER = "fcm";
+    private const int MAX_TOKEN_LENGTH = 4096;
+    private const int MAX_APP_VERSION_LENGTH = 128;
+
+    [HttpPut]
+    public async Task<IActionResult> Put(
+        string deviceId,
+        [FromBody] PushDeviceRegistrationRequest? request,
+        CancellationToken cancellationToken)
+    {
+        if (!TryNormalizeDeviceId(deviceId, out var normalizedDeviceId))
+        {
+            return BadRequest("deviceId must be a valid UUID");
+        }
+        if (request is null)
+        {
+            return BadRequest("registration body is required");
+        }
+
+        var platform = request.Platform?.Trim().ToLowerInvariant();
+        if (platform != ANDROID_PLATFORM)
+        {
+            return BadRequest("unsupported push platform");
+        }
+        var provider = request.Provider?.Trim().ToLowerInvariant();
+        if (provider != FCM_PROVIDER)
+        {
+            return BadRequest("unsupported push provider");
+        }
+        var pushToken = request.Token?.Trim();
+        if (string.IsNullOrEmpty(pushToken) || pushToken.Length > MAX_TOKEN_LENGTH)
+        {
+            return BadRequest("push token is invalid");
+        }
+        var appVersion = request.AppVersion?.Trim();
+        if (appVersion?.Length > MAX_APP_VERSION_LENGTH)
+        {
+            return BadRequest("appVersion is too long");
+        }
+        if (string.IsNullOrEmpty(appVersion))
+        {
+            appVersion = null;
+        }
+
+        await registry.UpsertAsync(
+            normalizedDeviceId,
+            platform,
+            provider,
+            pushToken,
+            appVersion,
+            cancellationToken);
+        return NoContent();
+    }
+
+    [HttpDelete]
+    public async Task<IActionResult> Delete(
+        string deviceId,
+        CancellationToken cancellationToken)
+    {
+        if (!TryNormalizeDeviceId(deviceId, out var normalizedDeviceId))
+        {
+            return BadRequest("deviceId must be a valid UUID");
+        }
+
+        await registry.RemoveAsync(normalizedDeviceId, cancellationToken);
+        return NoContent();
+    }
+
+    private static bool TryNormalizeDeviceId(string deviceId, out string normalizedDeviceId)
+    {
+        if (Guid.TryParse(deviceId, out var parsedDeviceId))
+        {
+            normalizedDeviceId = parsedDeviceId.ToString("D");
+            return true;
+        }
+
+        normalizedDeviceId = string.Empty;
+        return false;
+    }
+}

--- a/src/SyncClipboard.Server.Core/Controllers/PushDevicesController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/PushDevicesController.cs
@@ -22,7 +22,8 @@ public class PushDevicesController(IPushDeviceRegistry registry) : ControllerBas
         [FromBody] PushDeviceRegistrationRequest? request,
         CancellationToken cancellationToken)
     {
-        if (!TryNormalizeDeviceId(deviceId, out var normalizedDeviceId))
+        var normalizedDeviceId = SyncDeviceIdentity.Normalize(deviceId);
+        if (normalizedDeviceId is null)
         {
             return BadRequest("deviceId must be a valid UUID");
         }
@@ -71,24 +72,13 @@ public class PushDevicesController(IPushDeviceRegistry registry) : ControllerBas
         string deviceId,
         CancellationToken cancellationToken)
     {
-        if (!TryNormalizeDeviceId(deviceId, out var normalizedDeviceId))
+        var normalizedDeviceId = SyncDeviceIdentity.Normalize(deviceId);
+        if (normalizedDeviceId is null)
         {
             return BadRequest("deviceId must be a valid UUID");
         }
 
         await registry.RemoveAsync(normalizedDeviceId, cancellationToken);
         return NoContent();
-    }
-
-    private static bool TryNormalizeDeviceId(string deviceId, out string normalizedDeviceId)
-    {
-        if (Guid.TryParse(deviceId, out var parsedDeviceId))
-        {
-            normalizedDeviceId = parsedDeviceId.ToString("D");
-            return true;
-        }
-
-        normalizedDeviceId = string.Empty;
-        return false;
     }
 }

--- a/src/SyncClipboard.Server.Core/Controllers/SyncClipboardController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/SyncClipboardController.cs
@@ -6,6 +6,7 @@ using Microsoft.Extensions.Caching.Memory;
 using SyncClipboard.Server.Core.Services.History;
 using SyncClipboard.Server.Core.Services;
 using SyncClipboard.Server.Core.Services.Notifications;
+using SyncClipboard.Server.Core.Services.PushDevices;
 
 namespace SyncClipboard.Server.Core.Controllers;
 
@@ -153,7 +154,10 @@ public class SyncClipboardController(
     }
 
     [HttpPut("SyncClipboard.json")]
-    public async Task<IActionResult> PutSyncProfile([FromBody] ProfileDto dto, CancellationToken token)
+    public async Task<IActionResult> PutSyncProfile(
+        [FromBody] ProfileDto dto,
+        [FromHeader(Name = SyncDeviceIdentity.HeaderName)] string? originDeviceId,
+        CancellationToken token)
     {
         if (dto is null)
         {
@@ -167,12 +171,12 @@ public class SyncClipboardController(
 
             if (profile != null)
             {
-                await SaveAndNotifyCurrentProfile(profile, token);
+                await SaveAndNotifyCurrentProfile(profile, originDeviceId, token);
                 return Ok();
             }
         }
 
-        return await CreateAndSaveNewProfile(dto, token);
+        return await CreateAndSaveNewProfile(dto, originDeviceId, token);
     }
 
     [HttpGet("")]
@@ -182,7 +186,10 @@ public class SyncClipboardController(
         return Ok("Server is running.");
     }
 
-    private async Task<IActionResult> CreateAndSaveNewProfile(ProfileDto dto, CancellationToken token)
+    private async Task<IActionResult> CreateAndSaveNewProfile(
+        ProfileDto dto,
+        string? originDeviceId,
+        CancellationToken token)
     {
         var newProfile = Profile.Create(dto);
 
@@ -212,11 +219,14 @@ public class SyncClipboardController(
         }
 
         await _historyService.AddProfile(HistoryService.HARD_CODED_USER_ID, newProfile, token);
-        await SaveAndNotifyCurrentProfile(newProfile, token);
+        await SaveAndNotifyCurrentProfile(newProfile, originDeviceId, token);
         return Ok();
     }
 
-    private async Task SaveAndNotifyCurrentProfile(Profile profile, CancellationToken token)
+    private async Task SaveAndNotifyCurrentProfile(
+        Profile profile,
+        string? originDeviceId,
+        CancellationToken token)
     {
         var profileDto = await profile.ToProfileDto(token);
         var dataRoot = _serverEnv.GetDataRootPath();
@@ -226,7 +236,11 @@ public class SyncClipboardController(
         var profileText = JsonSerializer.Serialize(profileDto);
         await System.IO.File.WriteAllTextAsync(profilePath, profileText, token);
 
-        await _profileChangeNotifier.NotifyProfileChanged(profileDto, token);
+        await _profileChangeNotifier.NotifyProfileChanged(
+            new ProfileChangeNotification(
+                profileDto,
+                SyncDeviceIdentity.Normalize(originDeviceId)),
+            token);
     }
 
     private async Task<IActionResult> GetFileInternal(string? path)

--- a/src/SyncClipboard.Server.Core/Controllers/SyncClipboardController.cs
+++ b/src/SyncClipboard.Server.Core/Controllers/SyncClipboardController.cs
@@ -1,12 +1,11 @@
 ﻿using Microsoft.AspNetCore.Mvc;
-using Microsoft.AspNetCore.SignalR;
-using SyncClipboard.Server.Core.Hubs;
 using Microsoft.AspNetCore.StaticFiles;
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.Extensions.Caching.Memory;
 using SyncClipboard.Server.Core.Services.History;
 using SyncClipboard.Server.Core.Services;
+using SyncClipboard.Server.Core.Services.Notifications;
 
 namespace SyncClipboard.Server.Core.Controllers;
 
@@ -14,7 +13,7 @@ namespace SyncClipboard.Server.Core.Controllers;
 [Authorize]
 [Tags("SyncClipboard")]
 public class SyncClipboardController(
-    IHubContext<SyncClipboardHub, ISyncClipboardClient> _hubContext,
+    IProfileChangeNotifier _profileChangeNotifier,
     IMemoryCache _cache,
     ServerEnvProvider _serverEnv,
     HistoryService _historyService) : ControllerBase
@@ -227,7 +226,7 @@ public class SyncClipboardController(
         var profileText = JsonSerializer.Serialize(profileDto);
         await System.IO.File.WriteAllTextAsync(profilePath, profileText, token);
 
-        await _hubContext.Clients.All.RemoteProfileChanged(profileDto);
+        await _profileChangeNotifier.NotifyProfileChanged(profileDto, token);
     }
 
     private async Task<IActionResult> GetFileInternal(string? path)

--- a/src/SyncClipboard.Server.Core/Migrations/20260901061442_AddPushDeviceRegistry.Designer.cs
+++ b/src/SyncClipboard.Server.Core/Migrations/20260901061442_AddPushDeviceRegistry.Designer.cs
@@ -2,6 +2,7 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using SyncClipboard.Server.Core.Utilities.History;
 
@@ -10,9 +11,11 @@ using SyncClipboard.Server.Core.Utilities.History;
 namespace SyncClipboard.Server.Core.Migrations
 {
     [DbContext(typeof(HistoryDbContext))]
-    partial class HistoryDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260901061442_AddPushDeviceRegistry")]
+    partial class AddPushDeviceRegistry
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "9.0.8");

--- a/src/SyncClipboard.Server.Core/Migrations/20260901061442_AddPushDeviceRegistry.cs
+++ b/src/SyncClipboard.Server.Core/Migrations/20260901061442_AddPushDeviceRegistry.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace SyncClipboard.Server.Core.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPushDeviceRegistry : Migration
+    {
+        private static readonly string[] ProviderLastUpdatedColumns = ["Provider", "LastUpdated"];
+
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "PushDeviceRegistrations",
+                columns: table => new
+                {
+                    DeviceId = table.Column<string>(type: "TEXT", maxLength: 36, nullable: false),
+                    Platform = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    Provider = table.Column<string>(type: "TEXT", maxLength: 32, nullable: false),
+                    PushToken = table.Column<string>(type: "TEXT", maxLength: 4096, nullable: false),
+                    AppVersion = table.Column<string>(type: "TEXT", maxLength: 128, nullable: true),
+                    LastUpdated = table.Column<DateTimeOffset>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_PushDeviceRegistrations", x => x.DeviceId);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PushDeviceRegistrations_Provider_LastUpdated",
+                table: "PushDeviceRegistrations",
+                columns: ProviderLastUpdatedColumns);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "PushDeviceRegistrations");
+        }
+    }
+}

--- a/src/SyncClipboard.Server.Core/Models/AppSettings.cs
+++ b/src/SyncClipboard.Server.Core/Models/AppSettings.cs
@@ -6,4 +6,6 @@ public sealed class AppSettings
     public string Password { get; set; } = "admin";
     public uint MaxSavedHistoryCount { get; set; } = 1000;
     public uint HistoryRetentionMinutes { get; set; } = 10080;
+    public bool EnableFcmPush { get; set; }
+    public string? FirebaseProjectId { get; set; }
 }

--- a/src/SyncClipboard.Server.Core/Models/PushDeviceRegistration.cs
+++ b/src/SyncClipboard.Server.Core/Models/PushDeviceRegistration.cs
@@ -1,0 +1,48 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace SyncClipboard.Server.Core.Models;
+
+public sealed class PushDeviceRegistrationRequest
+{
+    public string? Platform { get; init; }
+    public string? Provider { get; init; }
+    public string? Token { get; init; }
+    public string? AppVersion { get; init; }
+}
+
+public sealed record PushDeviceRegistration(
+    string DeviceId,
+    string Platform,
+    string Provider,
+    string PushToken,
+    string? AppVersion,
+    DateTimeOffset LastUpdated);
+
+[Table("PushDeviceRegistrations")]
+public sealed class PushDeviceRegistrationEntity
+{
+    [Key]
+    [MaxLength(36)]
+    public string DeviceId { get; set; } = string.Empty;
+
+    [MaxLength(32)]
+    public string Platform { get; set; } = string.Empty;
+
+    [MaxLength(32)]
+    public string Provider { get; set; } = string.Empty;
+
+    [MaxLength(4096)]
+    public string PushToken { get; set; } = string.Empty;
+
+    [MaxLength(128)]
+    public string? AppVersion { get; set; }
+
+    public DateTimeOffset LastUpdated { get; set; }
+
+    public PushDeviceRegistration ToRegistration()
+    {
+        return new PushDeviceRegistration(
+            DeviceId, Platform, Provider, PushToken, AppVersion, LastUpdated);
+    }
+}

--- a/src/SyncClipboard.Server.Core/Models/RealtimeCapabilitiesDto.cs
+++ b/src/SyncClipboard.Server.Core/Models/RealtimeCapabilitiesDto.cs
@@ -1,0 +1,18 @@
+using System.Text.Json.Serialization;
+
+namespace SyncClipboard.Server.Core.Models;
+
+public sealed class RealtimeCapabilitiesDto
+{
+    [JsonPropertyName("signalR")]
+    public bool SignalR { get; init; }
+
+    [JsonPropertyName("push")]
+    public required PushCapabilitiesDto Push { get; init; }
+}
+
+public sealed class PushCapabilitiesDto
+{
+    [JsonPropertyName("fcm")]
+    public bool Fcm { get; init; }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/CompositeProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/CompositeProfileChangeNotifier.cs
@@ -1,0 +1,15 @@
+namespace SyncClipboard.Server.Core.Services.Notifications;
+
+public sealed class CompositeProfileChangeNotifier(
+    IEnumerable<IProfileChangeNotifier> notifiers) : IProfileChangeNotifier
+{
+    public async Task NotifyProfileChanged(
+        ProfileDto profile,
+        CancellationToken cancellationToken = default)
+    {
+        foreach (var notifier in notifiers)
+        {
+            await notifier.NotifyProfileChanged(profile, cancellationToken);
+        }
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/CompositeProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/CompositeProfileChangeNotifier.cs
@@ -4,12 +4,12 @@ public sealed class CompositeProfileChangeNotifier(
     IEnumerable<IProfileChangeNotifier> notifiers) : IProfileChangeNotifier
 {
     public async Task NotifyProfileChanged(
-        ProfileDto profile,
+        ProfileChangeNotification notification,
         CancellationToken cancellationToken = default)
     {
         foreach (var notifier in notifiers)
         {
-            await notifier.NotifyProfileChanged(profile, cancellationToken);
+            await notifier.NotifyProfileChanged(notification, cancellationToken);
         }
     }
 }

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmMessageFactory.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmMessageFactory.cs
@@ -1,0 +1,27 @@
+using FirebaseAdmin.Messaging;
+
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public static class FcmMessageFactory
+{
+    public static Message CreateProfileChangedMessage(string pushToken, string profileHash)
+    {
+        return new Message
+        {
+#pragma warning disable CS0618 // S4/M7 protocol uses FCM registration tokens, not Firebase installation IDs.
+            Token = pushToken,
+#pragma warning restore CS0618
+            Data = new Dictionary<string, string>
+            {
+                ["v"] = "1",
+                ["type"] = "clipboard_changed",
+                ["hash"] = profileHash
+            },
+            Android = new AndroidConfig
+            {
+                CollapseKey = "clipboard",
+                Priority = Priority.Normal
+            }
+        };
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeDelivery.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeDelivery.cs
@@ -64,6 +64,37 @@ public sealed class FcmProfileChangeDelivery(
             await fcmClient.SendProfileChangedAsync(
                 registration.PushToken, profileHash, cancellationToken);
         }
+        catch (InvalidFcmRegistrationException ex)
+        {
+            try
+            {
+                var removed = await registry.RemoveIfTokenMatchesAsync(
+                    registration.DeviceId,
+                    registration.PushToken,
+                    cancellationToken);
+                if (removed)
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Removed permanently invalid FCM registration for device {DeviceId}",
+                        registration.DeviceId);
+                }
+                else
+                {
+                    logger.LogWarning(
+                        ex,
+                        "Did not remove FCM registration for device {DeviceId} because its token changed",
+                        registration.DeviceId);
+                }
+            }
+            catch (Exception removeException) when (!cancellationToken.IsCancellationRequested)
+            {
+                logger.LogWarning(
+                    removeException,
+                    "Failed to remove permanently invalid FCM registration for device {DeviceId}",
+                    registration.DeviceId);
+            }
+        }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {
             logger.LogWarning(

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeDelivery.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeDelivery.cs
@@ -1,0 +1,75 @@
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed class FcmProfileChangeDelivery(
+    IPushDeviceRegistry registry,
+    IFcmPushClient fcmClient,
+    ILogger<FcmProfileChangeDelivery> logger)
+{
+    public async Task DeliverAsync(
+        FcmProfileChangeHint hint,
+        CancellationToken cancellationToken = default)
+    {
+        if (!fcmClient.IsAvailable)
+        {
+            logger.LogDebug("Skipping FCM profile change hint because provider is unavailable");
+            return;
+        }
+
+        IReadOnlyList<PushDeviceRegistration> registrations;
+        try
+        {
+            registrations = await registry.GetByProviderAsync("fcm", cancellationToken);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Failed to read FCM push registrations");
+            return;
+        }
+
+        var recipients = registrations
+            .Where(registration => !string.Equals(
+                registration.DeviceId,
+                hint.OriginDeviceId,
+                StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        var excludedDeviceCount = registrations.Count - recipients.Count;
+        if (excludedDeviceCount > 0)
+        {
+            logger.LogDebug(
+                "Excluded originating device {OriginDeviceId} from FCM profile change hint",
+                hint.OriginDeviceId);
+        }
+
+        foreach (var registration in recipients)
+        {
+            await SendToDeviceAsync(registration, hint.ProfileHash, cancellationToken);
+        }
+
+        logger.LogDebug(
+            "FCM profile change hint processed for {DeviceCount} devices; {ExcludedDeviceCount} origin devices excluded",
+            recipients.Count,
+            excludedDeviceCount);
+    }
+
+    private async Task SendToDeviceAsync(
+        PushDeviceRegistration registration,
+        string profileHash,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await fcmClient.SendProfileChangedAsync(
+                registration.PushToken, profileHash, cancellationToken);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to send FCM profile change hint to device {DeviceId}",
+                registration.DeviceId);
+        }
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
@@ -1,0 +1,54 @@
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed class FcmProfileChangeNotifier(
+    IPushDeviceRegistry registry,
+    IFcmPushClient fcmClient,
+    ILogger<FcmProfileChangeNotifier> logger) : IProfileChangeNotifier
+{
+    public async Task NotifyProfileChanged(
+        ProfileDto profile,
+        CancellationToken cancellationToken = default)
+    {
+        if (!fcmClient.IsAvailable)
+        {
+            logger.LogDebug("Skipping FCM profile change hint because provider is unavailable");
+            return;
+        }
+
+        try
+        {
+            var registrations = await registry.GetByProviderAsync("fcm", cancellationToken);
+            await Task.WhenAll(registrations.Select(registration =>
+                SendToDeviceAsync(registration, profile.Hash, cancellationToken)));
+            logger.LogDebug(
+                "FCM profile change hint processed for {DeviceCount} registered devices",
+                registrations.Count);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(ex, "Failed to process FCM profile change hints");
+        }
+    }
+
+    private async Task SendToDeviceAsync(
+        PushDeviceRegistration registration,
+        string profileHash,
+        CancellationToken cancellationToken)
+    {
+        try
+        {
+            await fcmClient.SendProfileChangedAsync(
+                registration.PushToken, profileHash, cancellationToken);
+        }
+        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        {
+            logger.LogWarning(
+                ex,
+                "Failed to send FCM profile change hint to device {DeviceId}",
+                registration.DeviceId);
+        }
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
@@ -9,7 +9,7 @@ public sealed class FcmProfileChangeNotifier(
     ILogger<FcmProfileChangeNotifier> logger) : IProfileChangeNotifier
 {
     public async Task NotifyProfileChanged(
-        ProfileDto profile,
+        ProfileChangeNotification notification,
         CancellationToken cancellationToken = default)
     {
         if (!fcmClient.IsAvailable)
@@ -21,11 +21,29 @@ public sealed class FcmProfileChangeNotifier(
         try
         {
             var registrations = await registry.GetByProviderAsync("fcm", cancellationToken);
-            await Task.WhenAll(registrations.Select(registration =>
-                SendToDeviceAsync(registration, profile.Hash, cancellationToken)));
+            var recipients = registrations
+                .Where(registration => !string.Equals(
+                    registration.DeviceId,
+                    notification.OriginDeviceId,
+                    StringComparison.OrdinalIgnoreCase))
+                .ToList();
+            var excludedDeviceCount = registrations.Count - recipients.Count;
+            if (excludedDeviceCount > 0)
+            {
+                logger.LogDebug(
+                    "Excluded originating device {OriginDeviceId} from FCM profile change hint",
+                    notification.OriginDeviceId);
+            }
+
+            await Task.WhenAll(recipients.Select(registration =>
+                SendToDeviceAsync(
+                    registration,
+                    notification.Profile.Hash,
+                    cancellationToken)));
             logger.LogDebug(
-                "FCM profile change hint processed for {DeviceCount} registered devices",
-                registrations.Count);
+                "FCM profile change hint processed for {DeviceCount} devices; {ExcludedDeviceCount} origin devices excluded",
+                recipients.Count,
+                excludedDeviceCount);
         }
         catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
         {

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeNotifier.cs
@@ -1,72 +1,36 @@
-using SyncClipboard.Server.Core.Models;
-using SyncClipboard.Server.Core.Services.PushDevices;
-
 namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
 
 public sealed class FcmProfileChangeNotifier(
-    IPushDeviceRegistry registry,
+    IFcmProfileChangeQueue queue,
     IFcmPushClient fcmClient,
     ILogger<FcmProfileChangeNotifier> logger) : IProfileChangeNotifier
 {
-    public async Task NotifyProfileChanged(
+    public Task NotifyProfileChanged(
         ProfileChangeNotification notification,
         CancellationToken cancellationToken = default)
     {
         if (!fcmClient.IsAvailable)
         {
             logger.LogDebug("Skipping FCM profile change hint because provider is unavailable");
-            return;
+            return Task.CompletedTask;
         }
 
-        try
+        var hint = new FcmProfileChangeHint(
+            notification.Profile.Hash,
+            notification.OriginDeviceId);
+        if (queue.TryEnqueue(hint))
         {
-            var registrations = await registry.GetByProviderAsync("fcm", cancellationToken);
-            var recipients = registrations
-                .Where(registration => !string.Equals(
-                    registration.DeviceId,
-                    notification.OriginDeviceId,
-                    StringComparison.OrdinalIgnoreCase))
-                .ToList();
-            var excludedDeviceCount = registrations.Count - recipients.Count;
-            if (excludedDeviceCount > 0)
-            {
-                logger.LogDebug(
-                    "Excluded originating device {OriginDeviceId} from FCM profile change hint",
-                    notification.OriginDeviceId);
-            }
-
-            await Task.WhenAll(recipients.Select(registration =>
-                SendToDeviceAsync(
-                    registration,
-                    notification.Profile.Hash,
-                    cancellationToken)));
             logger.LogDebug(
-                "FCM profile change hint processed for {DeviceCount} devices; {ExcludedDeviceCount} origin devices excluded",
-                recipients.Count,
-                excludedDeviceCount);
+                "Queued FCM profile change hint for profile {ProfileHash}",
+                notification.Profile.Hash);
         }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
-        {
-            logger.LogWarning(ex, "Failed to process FCM profile change hints");
-        }
-    }
-
-    private async Task SendToDeviceAsync(
-        PushDeviceRegistration registration,
-        string profileHash,
-        CancellationToken cancellationToken)
-    {
-        try
-        {
-            await fcmClient.SendProfileChangedAsync(
-                registration.PushToken, profileHash, cancellationToken);
-        }
-        catch (Exception ex) when (!cancellationToken.IsCancellationRequested)
+        else
         {
             logger.LogWarning(
-                ex,
-                "Failed to send FCM profile change hint to device {DeviceId}",
-                registration.DeviceId);
+                "Dropped FCM profile change hint for profile {ProfileHash} because the delivery queue is unavailable",
+                notification.Profile.Hash);
         }
+
+        return Task.CompletedTask;
     }
 }

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeQueue.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeQueue.cs
@@ -1,0 +1,37 @@
+using System.Threading.Channels;
+
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed record FcmProfileChangeHint(
+    string ProfileHash,
+    string? OriginDeviceId);
+
+public interface IFcmProfileChangeQueue
+{
+    bool TryEnqueue(FcmProfileChangeHint hint);
+
+    ValueTask<FcmProfileChangeHint> DequeueAsync(
+        CancellationToken cancellationToken = default);
+}
+
+public sealed class FcmProfileChangeQueue : IFcmProfileChangeQueue
+{
+    private readonly Channel<FcmProfileChangeHint> _channel =
+        Channel.CreateBounded<FcmProfileChangeHint>(new BoundedChannelOptions(1)
+        {
+            FullMode = BoundedChannelFullMode.DropOldest,
+            SingleReader = true,
+            SingleWriter = false
+        });
+
+    public bool TryEnqueue(FcmProfileChangeHint hint)
+    {
+        return _channel.Writer.TryWrite(hint);
+    }
+
+    public ValueTask<FcmProfileChangeHint> DequeueAsync(
+        CancellationToken cancellationToken = default)
+    {
+        return _channel.Reader.ReadAsync(cancellationToken);
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeWorker.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FcmProfileChangeWorker.cs
@@ -1,0 +1,48 @@
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed class FcmProfileChangeWorker(
+    IFcmProfileChangeQueue queue,
+    IServiceScopeFactory serviceScopeFactory,
+    ILogger<FcmProfileChangeWorker> logger) : BackgroundService
+{
+    private static readonly TimeSpan DeliveryTimeout = TimeSpan.FromSeconds(30);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            FcmProfileChangeHint hint;
+            try
+            {
+                hint = await queue.DequeueAsync(stoppingToken);
+            }
+            catch (OperationCanceledException) when (stoppingToken.IsCancellationRequested)
+            {
+                break;
+            }
+
+            using var scope = serviceScopeFactory.CreateScope();
+            var delivery = scope.ServiceProvider.GetRequiredService<FcmProfileChangeDelivery>();
+            using var deliveryTimeout = CancellationTokenSource.CreateLinkedTokenSource(stoppingToken);
+            deliveryTimeout.CancelAfter(DeliveryTimeout);
+            try
+            {
+                await delivery.DeliverAsync(hint, deliveryTimeout.Token);
+            }
+            catch (OperationCanceledException) when (
+                !stoppingToken.IsCancellationRequested && deliveryTimeout.IsCancellationRequested)
+            {
+                logger.LogWarning(
+                    "FCM profile change delivery timed out for profile {ProfileHash}",
+                    hint.ProfileHash);
+            }
+            catch (Exception ex) when (!stoppingToken.IsCancellationRequested)
+            {
+                logger.LogWarning(
+                    ex,
+                    "Unexpected failure delivering FCM profile change hint for profile {ProfileHash}",
+                    hint.ProfileHash);
+            }
+        }
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FirebaseAdminFcmPushClient.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FirebaseAdminFcmPushClient.cs
@@ -1,0 +1,69 @@
+using FirebaseAdmin;
+using FirebaseAdmin.Messaging;
+using Google.Apis.Auth.OAuth2;
+using Microsoft.Extensions.Options;
+using SyncClipboard.Server.Core.Models;
+
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed class FirebaseAdminFcmPushClient : IFcmPushClient, IDisposable
+{
+    private readonly ILogger<FirebaseAdminFcmPushClient> _logger;
+    private FirebaseApp? _firebaseApp;
+    private FirebaseMessaging? _messaging;
+
+    public FirebaseAdminFcmPushClient(
+        IOptions<AppSettings> options,
+        ILogger<FirebaseAdminFcmPushClient> logger)
+    {
+        _logger = logger;
+        if (!options.Value.EnableFcmPush)
+        {
+            logger.LogDebug("FCM push provider is disabled by configuration");
+            return;
+        }
+
+        try
+        {
+            var appOptions = new AppOptions
+            {
+                Credential = GoogleCredential.GetApplicationDefault(),
+                ProjectId = string.IsNullOrWhiteSpace(options.Value.FirebaseProjectId)
+                    ? null
+                    : options.Value.FirebaseProjectId.Trim()
+            };
+            _firebaseApp = FirebaseApp.Create(
+                appOptions, $"syncclipboard-{Guid.NewGuid():N}");
+            _messaging = FirebaseMessaging.GetMessaging(_firebaseApp);
+            logger.LogInformation("FCM push provider initialized");
+        }
+        catch (Exception ex)
+        {
+            logger.LogError(ex, "FCM push provider initialization failed; push remains unavailable");
+        }
+    }
+
+    public bool IsAvailable => _messaging is not null;
+
+    public async Task SendProfileChangedAsync(
+        string pushToken,
+        string profileHash,
+        CancellationToken cancellationToken = default)
+    {
+        if (_messaging is null)
+        {
+            throw new InvalidOperationException("FCM push provider is unavailable");
+        }
+
+        var message = FcmMessageFactory.CreateProfileChangedMessage(pushToken, profileHash);
+        await _messaging.SendAsync(message, cancellationToken);
+    }
+
+    public void Dispose()
+    {
+        _messaging = null;
+        _firebaseApp?.Delete();
+        _firebaseApp = null;
+        GC.SuppressFinalize(this);
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FirebaseAdminFcmPushClient.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/FirebaseAdminFcmPushClient.cs
@@ -56,7 +56,17 @@ public sealed class FirebaseAdminFcmPushClient : IFcmPushClient, IDisposable
         }
 
         var message = FcmMessageFactory.CreateProfileChangedMessage(pushToken, profileHash);
-        await _messaging.SendAsync(message, cancellationToken);
+        try
+        {
+            await _messaging.SendAsync(message, cancellationToken);
+        }
+        catch (FirebaseMessagingException ex)
+            when (ex.MessagingErrorCode == MessagingErrorCode.Unregistered)
+        {
+            throw new InvalidFcmRegistrationException(
+                "FCM registration is permanently unregistered",
+                ex);
+        }
     }
 
     public void Dispose()

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/IFcmPushClient.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/IFcmPushClient.cs
@@ -1,0 +1,11 @@
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public interface IFcmPushClient
+{
+    bool IsAvailable { get; }
+
+    Task SendProfileChangedAsync(
+        string pushToken,
+        string profileHash,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/InvalidFcmRegistrationException.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/Fcm/InvalidFcmRegistrationException.cs
@@ -1,0 +1,5 @@
+namespace SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+public sealed class InvalidFcmRegistrationException(
+    string message,
+    Exception innerException) : Exception(message, innerException);

--- a/src/SyncClipboard.Server.Core/Services/Notifications/IProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/IProfileChangeNotifier.cs
@@ -2,5 +2,7 @@ namespace SyncClipboard.Server.Core.Services.Notifications;
 
 public interface IProfileChangeNotifier
 {
-    Task NotifyProfileChanged(ProfileDto profile, CancellationToken cancellationToken = default);
+    Task NotifyProfileChanged(
+        ProfileChangeNotification notification,
+        CancellationToken cancellationToken = default);
 }

--- a/src/SyncClipboard.Server.Core/Services/Notifications/IProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/IProfileChangeNotifier.cs
@@ -1,0 +1,6 @@
+namespace SyncClipboard.Server.Core.Services.Notifications;
+
+public interface IProfileChangeNotifier
+{
+    Task NotifyProfileChanged(ProfileDto profile, CancellationToken cancellationToken = default);
+}

--- a/src/SyncClipboard.Server.Core/Services/Notifications/ProfileChangeNotification.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/ProfileChangeNotification.cs
@@ -1,0 +1,5 @@
+namespace SyncClipboard.Server.Core.Services.Notifications;
+
+public sealed record ProfileChangeNotification(
+    ProfileDto Profile,
+    string? OriginDeviceId = null);

--- a/src/SyncClipboard.Server.Core/Services/Notifications/SignalRProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/SignalRProfileChangeNotifier.cs
@@ -7,9 +7,9 @@ public class SignalRProfileChangeNotifier(
     IHubContext<SyncClipboardHub, ISyncClipboardClient> hubContext) : IProfileChangeNotifier
 {
     public Task NotifyProfileChanged(
-        ProfileDto profile,
+        ProfileChangeNotification notification,
         CancellationToken cancellationToken = default)
     {
-        return hubContext.Clients.All.RemoteProfileChanged(profile);
+        return hubContext.Clients.All.RemoteProfileChanged(notification.Profile);
     }
 }

--- a/src/SyncClipboard.Server.Core/Services/Notifications/SignalRProfileChangeNotifier.cs
+++ b/src/SyncClipboard.Server.Core/Services/Notifications/SignalRProfileChangeNotifier.cs
@@ -1,0 +1,15 @@
+using Microsoft.AspNetCore.SignalR;
+using SyncClipboard.Server.Core.Hubs;
+
+namespace SyncClipboard.Server.Core.Services.Notifications;
+
+public class SignalRProfileChangeNotifier(
+    IHubContext<SyncClipboardHub, ISyncClipboardClient> hubContext) : IProfileChangeNotifier
+{
+    public Task NotifyProfileChanged(
+        ProfileDto profile,
+        CancellationToken cancellationToken = default)
+    {
+        return hubContext.Clients.All.RemoteProfileChanged(profile);
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/PushDevices/IPushDeviceRegistry.cs
+++ b/src/SyncClipboard.Server.Core/Services/PushDevices/IPushDeviceRegistry.cs
@@ -1,0 +1,22 @@
+using SyncClipboard.Server.Core.Models;
+
+namespace SyncClipboard.Server.Core.Services.PushDevices;
+
+public interface IPushDeviceRegistry
+{
+    Task UpsertAsync(
+        string deviceId,
+        string platform,
+        string provider,
+        string pushToken,
+        string? appVersion,
+        CancellationToken cancellationToken = default);
+
+    Task<bool> RemoveAsync(
+        string deviceId,
+        CancellationToken cancellationToken = default);
+
+    Task<IReadOnlyList<PushDeviceRegistration>> GetByProviderAsync(
+        string provider,
+        CancellationToken cancellationToken = default);
+}

--- a/src/SyncClipboard.Server.Core/Services/PushDevices/IPushDeviceRegistry.cs
+++ b/src/SyncClipboard.Server.Core/Services/PushDevices/IPushDeviceRegistry.cs
@@ -16,6 +16,11 @@ public interface IPushDeviceRegistry
         string deviceId,
         CancellationToken cancellationToken = default);
 
+    Task<bool> RemoveIfTokenMatchesAsync(
+        string deviceId,
+        string pushToken,
+        CancellationToken cancellationToken = default);
+
     Task<IReadOnlyList<PushDeviceRegistration>> GetByProviderAsync(
         string provider,
         CancellationToken cancellationToken = default);

--- a/src/SyncClipboard.Server.Core/Services/PushDevices/PushDeviceRegistry.cs
+++ b/src/SyncClipboard.Server.Core/Services/PushDevices/PushDeviceRegistry.cs
@@ -1,0 +1,67 @@
+using Microsoft.EntityFrameworkCore;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Utilities.History;
+
+namespace SyncClipboard.Server.Core.Services.PushDevices;
+
+public class PushDeviceRegistry(
+    HistoryDbContext dbContext,
+    ILogger<PushDeviceRegistry> logger) : IPushDeviceRegistry
+{
+    public async Task UpsertAsync(
+        string deviceId,
+        string platform,
+        string provider,
+        string pushToken,
+        string? appVersion,
+        CancellationToken cancellationToken = default)
+    {
+        var lastUpdated = DateTimeOffset.UtcNow;
+        await dbContext.Database.ExecuteSqlInterpolatedAsync($"""
+            INSERT INTO "PushDeviceRegistrations"
+                ("DeviceId", "Platform", "Provider", "PushToken", "AppVersion", "LastUpdated")
+            VALUES
+                ({deviceId}, {platform}, {provider}, {pushToken}, {appVersion}, {lastUpdated})
+            ON CONFLICT ("DeviceId") DO UPDATE SET
+                "Platform" = excluded."Platform",
+                "Provider" = excluded."Provider",
+                "PushToken" = excluded."PushToken",
+                "AppVersion" = excluded."AppVersion",
+                "LastUpdated" = excluded."LastUpdated";
+            """, cancellationToken);
+
+        logger.LogDebug(
+            "Upserted push registration for device {DeviceId} using {Provider}",
+            deviceId,
+            provider);
+    }
+
+    public async Task<bool> RemoveAsync(
+        string deviceId,
+        CancellationToken cancellationToken = default)
+    {
+        var registration = await dbContext.PushDeviceRegistrations
+            .SingleOrDefaultAsync(value => value.DeviceId == deviceId, cancellationToken);
+        if (registration is null)
+        {
+            logger.LogDebug("Push registration already absent for device {DeviceId}", deviceId);
+            return false;
+        }
+
+        dbContext.PushDeviceRegistrations.Remove(registration);
+        await dbContext.SaveChangesAsync(cancellationToken);
+        logger.LogDebug("Removed push registration for device {DeviceId}", deviceId);
+        return true;
+    }
+
+    public async Task<IReadOnlyList<PushDeviceRegistration>> GetByProviderAsync(
+        string provider,
+        CancellationToken cancellationToken = default)
+    {
+        var registrations = await dbContext.PushDeviceRegistrations
+            .AsNoTracking()
+            .Where(value => value.Provider == provider)
+            .ToListAsync(cancellationToken);
+        return registrations.Select(value => value.ToRegistration()).ToList();
+    }
+}

--- a/src/SyncClipboard.Server.Core/Services/PushDevices/PushDeviceRegistry.cs
+++ b/src/SyncClipboard.Server.Core/Services/PushDevices/PushDeviceRegistry.cs
@@ -40,11 +40,34 @@ public class PushDeviceRegistry(
         string deviceId,
         CancellationToken cancellationToken = default)
     {
-        var registration = await dbContext.PushDeviceRegistrations
-            .SingleOrDefaultAsync(value => value.DeviceId == deviceId, cancellationToken);
+        return await RemoveInternalAsync(deviceId, pushToken: null, cancellationToken);
+    }
+
+    public async Task<bool> RemoveIfTokenMatchesAsync(
+        string deviceId,
+        string pushToken,
+        CancellationToken cancellationToken = default)
+    {
+        return await RemoveInternalAsync(deviceId, pushToken, cancellationToken);
+    }
+
+    private async Task<bool> RemoveInternalAsync(
+        string deviceId,
+        string? pushToken,
+        CancellationToken cancellationToken)
+    {
+        var query = dbContext.PushDeviceRegistrations
+            .Where(value => value.DeviceId == deviceId);
+        if (pushToken is not null)
+        {
+            query = query.Where(value => value.PushToken == pushToken);
+        }
+        var registration = await query.SingleOrDefaultAsync(cancellationToken);
         if (registration is null)
         {
-            logger.LogDebug("Push registration already absent for device {DeviceId}", deviceId);
+            logger.LogDebug(
+                "Push registration already absent or changed for device {DeviceId}",
+                deviceId);
             return false;
         }
 

--- a/src/SyncClipboard.Server.Core/Services/PushDevices/SyncDeviceIdentity.cs
+++ b/src/SyncClipboard.Server.Core/Services/PushDevices/SyncDeviceIdentity.cs
@@ -1,0 +1,13 @@
+namespace SyncClipboard.Server.Core.Services.PushDevices;
+
+public static class SyncDeviceIdentity
+{
+    public const string HeaderName = "X-SyncClipboard-Device-Id";
+
+    public static string? Normalize(string? deviceId)
+    {
+        return Guid.TryParse(deviceId, out var parsedDeviceId)
+            ? parsedDeviceId.ToString("D")
+            : null;
+    }
+}

--- a/src/SyncClipboard.Server.Core/SyncClipboard.Server.Core.csproj
+++ b/src/SyncClipboard.Server.Core/SyncClipboard.Server.Core.csproj
@@ -22,4 +22,8 @@
     <ProjectReference Include="..\SyncClipboard.Shared\SyncClipboard.Shared.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <InternalsVisibleTo Include="SyncClipboard.Test" />
+  </ItemGroup>
+
 </Project>

--- a/src/SyncClipboard.Server.Core/SyncClipboard.Server.Core.csproj
+++ b/src/SyncClipboard.Server.Core/SyncClipboard.Server.Core.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" />
+    <PackageReference Include="FirebaseAdmin" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/SyncClipboard.Server.Core/Utilities/History/HistoryDbContext.cs
+++ b/src/SyncClipboard.Server.Core/Utilities/History/HistoryDbContext.cs
@@ -26,6 +26,7 @@ public class HistoryDbContext : DbContext
     }
 
     public DbSet<HistoryRecordEntity> HistoryRecords { get; set; } = null!;
+    public DbSet<PushDeviceRegistrationEntity> PushDeviceRegistrations { get; set; } = null!;
 
     protected override void OnConfiguring(DbContextOptionsBuilder options)
     {
@@ -50,6 +51,10 @@ public class HistoryDbContext : DbContext
         modelBuilder.Entity<HistoryRecordEntity>()
             .HasIndex(e => new { e.UserId, e.Stared, e.Type, e.CreateTime, e.ID })
             .HasDatabaseName("IX_History_User_Stared_Type_CreateTime_ID");
+
+        modelBuilder.Entity<PushDeviceRegistrationEntity>()
+            .HasIndex(e => new { e.Provider, e.LastUpdated })
+            .HasDatabaseName("IX_PushDeviceRegistrations_Provider_LastUpdated");
 
         base.OnModelCreating(modelBuilder);
     }

--- a/src/SyncClipboard.Server.Core/Web.cs
+++ b/src/SyncClipboard.Server.Core/Web.cs
@@ -6,6 +6,7 @@ using SyncClipboard.Server.Core.Hubs;
 using SyncClipboard.Server.Core.Models;
 using SyncClipboard.Server.Core.Services;
 using SyncClipboard.Server.Core.Services.History;
+using SyncClipboard.Server.Core.Services.Notifications;
 using SyncClipboard.Server.Core.Swagger;
 using SyncClipboard.Server.Core.Utilities;
 using SyncClipboard.Server.Core.Utilities.History;
@@ -36,6 +37,7 @@ public class Web
             .AddApplicationPart(typeof(SyncClipboardController).Assembly);
         services.AddMemoryCache();
         services.AddSignalR();
+        services.AddSingleton<IProfileChangeNotifier, SignalRProfileChangeNotifier>();
 
         services.AddDbContext<HistoryDbContext>();
         services.AddScoped<HistoryService>();

--- a/src/SyncClipboard.Server.Core/Web.cs
+++ b/src/SyncClipboard.Server.Core/Web.cs
@@ -41,6 +41,8 @@ public class Web
         services.AddSignalR();
         services.AddSingleton<SignalRProfileChangeNotifier>();
         services.AddSingleton<IFcmPushClient, FirebaseAdminFcmPushClient>();
+        services.AddSingleton<IFcmProfileChangeQueue, FcmProfileChangeQueue>();
+        services.AddScoped<FcmProfileChangeDelivery>();
         services.AddScoped<FcmProfileChangeNotifier>();
         services.AddScoped<IProfileChangeNotifier>(provider =>
             new CompositeProfileChangeNotifier([
@@ -62,6 +64,7 @@ public class Web
 
         services.AddServerProfileEnvProvider();
         services.AddHostedService<HistoryCleaner>();
+        services.AddHostedService<FcmProfileChangeWorker>();
 
         // This is minimal api project, but Swagger use Microsoft.AspNetCore.Mvc.JsonOptions to show enum as string.
         // The real working converter is written in dto definition in form of attribute. 

--- a/src/SyncClipboard.Server.Core/Web.cs
+++ b/src/SyncClipboard.Server.Core/Web.cs
@@ -129,14 +129,28 @@ public class Web
                 serverOptions.ListenAnyIP(serverConfig.Port, OptionAction);
             });
         }
-        builder.Services.Configure<AppSettings>(option =>
-        {
-            option.MaxSavedHistoryCount = serverConfig.MaxSavedHistoryCount;
-            option.HistoryRetentionMinutes = serverConfig.HistoryRetentionMinutes;
-        });
+        ConfigureEmbeddedServerAppSettings(
+            builder.Services,
+            builder.Configuration,
+            serverConfig.MaxSavedHistoryCount,
+            serverConfig.HistoryRetentionMinutes);
         builder.Services.AddSingleton<ICredentialChecker, StaticCredentialChecker>(_ => new StaticCredentialChecker(serverConfig.UserName, serverConfig.Password));
         var app = Configure(builder, serverConfig.DiagnoseMode);
         await app.StartAsync();
         return app;
+    }
+
+    internal static void ConfigureEmbeddedServerAppSettings(
+        IServiceCollection services,
+        IConfiguration configuration,
+        uint maxSavedHistoryCount,
+        uint historyRetentionMinutes)
+    {
+        services.Configure<AppSettings>(configuration.GetSection(nameof(AppSettings)));
+        services.PostConfigure<AppSettings>(option =>
+        {
+            option.MaxSavedHistoryCount = maxSavedHistoryCount;
+            option.HistoryRetentionMinutes = historyRetentionMinutes;
+        });
     }
 }

--- a/src/SyncClipboard.Server.Core/Web.cs
+++ b/src/SyncClipboard.Server.Core/Web.cs
@@ -7,6 +7,7 @@ using SyncClipboard.Server.Core.Models;
 using SyncClipboard.Server.Core.Services;
 using SyncClipboard.Server.Core.Services.History;
 using SyncClipboard.Server.Core.Services.Notifications;
+using SyncClipboard.Server.Core.Services.PushDevices;
 using SyncClipboard.Server.Core.Swagger;
 using SyncClipboard.Server.Core.Utilities;
 using SyncClipboard.Server.Core.Utilities.History;
@@ -41,6 +42,7 @@ public class Web
 
         services.AddDbContext<HistoryDbContext>();
         services.AddScoped<HistoryService>();
+        services.AddScoped<IPushDeviceRegistry, PushDeviceRegistry>();
 
         // Learn more about configuring Swagger/OpenAPI at https://aka.ms/aspnetcore/swashbuckle
         services.AddEndpointsApiExplorer();

--- a/src/SyncClipboard.Server.Core/Web.cs
+++ b/src/SyncClipboard.Server.Core/Web.cs
@@ -7,6 +7,7 @@ using SyncClipboard.Server.Core.Models;
 using SyncClipboard.Server.Core.Services;
 using SyncClipboard.Server.Core.Services.History;
 using SyncClipboard.Server.Core.Services.Notifications;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
 using SyncClipboard.Server.Core.Services.PushDevices;
 using SyncClipboard.Server.Core.Swagger;
 using SyncClipboard.Server.Core.Utilities;
@@ -38,7 +39,14 @@ public class Web
             .AddApplicationPart(typeof(SyncClipboardController).Assembly);
         services.AddMemoryCache();
         services.AddSignalR();
-        services.AddSingleton<IProfileChangeNotifier, SignalRProfileChangeNotifier>();
+        services.AddSingleton<SignalRProfileChangeNotifier>();
+        services.AddSingleton<IFcmPushClient, FirebaseAdminFcmPushClient>();
+        services.AddScoped<FcmProfileChangeNotifier>();
+        services.AddScoped<IProfileChangeNotifier>(provider =>
+            new CompositeProfileChangeNotifier([
+                provider.GetRequiredService<SignalRProfileChangeNotifier>(),
+                provider.GetRequiredService<FcmProfileChangeNotifier>()
+            ]));
 
         services.AddDbContext<HistoryDbContext>();
         services.AddScoped<HistoryService>();

--- a/src/SyncClipboard.Server/README_DOCKER.md
+++ b/src/SyncClipboard.Server/README_DOCKER.md
@@ -38,7 +38,9 @@ When you wish to configure server settings on your own, follow the template belo
   },
   "AppSettings": {
     "UserName": "admin",
-    "Password": "admin"
+    "Password": "admin",
+    "EnableFcmPush": false,
+    "FirebaseProjectId": null
   }
 }
 ```
@@ -64,6 +66,16 @@ docker run -d \
 | -p 5033              | 端口映射 \| Port mapping, [hostport:containerport]   |
 | -v /appsettings.json | 路径映射 \| Volume mapping, [hostpath:containerpath] |
 | --restart            | 重启策略 \|  Restart Policy                          |
+
+## 可选 FCM Push | Optional FCM Push
+
+FCM 默认关闭。启用时，将 `AppSettings.EnableFcmPush` 设为 `true`，并按 Firebase Admin SDK 的要求通过 `GOOGLE_APPLICATION_CREDENTIALS` 提供服务账号文件路径。可使用 `AppSettings.FirebaseProjectId` 显式指定 Firebase project ID。
+
+FCM is disabled by default. To enable it, set `AppSettings.EnableFcmPush` to `true` and provide the service-account file path through `GOOGLE_APPLICATION_CREDENTIALS`, as required by the Firebase Admin SDK. `AppSettings.FirebaseProjectId` can explicitly select the Firebase project.
+
+只有 Firebase Admin 初始化成功时，`GET /api/capabilities` 才会返回 `push.fcm: true`。服务账号内容不会写入应用配置或日志。
+
+`GET /api/capabilities` reports `push.fcm: true` only after Firebase Admin initializes successfully. Service-account contents are never stored in app configuration or logs.
 
 ----
 

--- a/src/SyncClipboard.Server/appsettings.json
+++ b/src/SyncClipboard.Server/appsettings.json
@@ -26,6 +26,8 @@
     "UserName": "your_username",
     "Password": "your_password",
     "MaxSavedHistoryCount": 1000,
-    "HistoryRetentionMinutes": 10080
+    "HistoryRetentionMinutes": 10080,
+    "EnableFcmPush": false,
+    "FirebaseProjectId": null
   }
 }

--- a/src/SyncClipboard.Test/CapabilitiesControllerTests.cs
+++ b/src/SyncClipboard.Test/CapabilitiesControllerTests.cs
@@ -1,0 +1,51 @@
+using System.Text.Json;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using SyncClipboard.Server.Core.Controllers;
+using SyncClipboard.Server.Core.Models;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class CapabilitiesControllerTests
+{
+    [TestMethod]
+    public void Get_ReturnsCurrentRealtimeTransportCapabilities()
+    {
+        var controller = new CapabilitiesController();
+
+        var result = controller.Get();
+
+        var ok = result.Result as OkObjectResult;
+        Assert.IsNotNull(ok);
+        var capabilities = ok.Value as RealtimeCapabilitiesDto;
+        Assert.IsNotNull(capabilities);
+        Assert.IsTrue(capabilities.SignalR);
+        Assert.IsFalse(capabilities.Push.Fcm);
+    }
+
+    [TestMethod]
+    public void Contract_UsesAuthenticatedApiCapabilitiesRouteAndStableJsonNames()
+    {
+        var controllerType = typeof(CapabilitiesController);
+        var route = controllerType.GetCustomAttributes(typeof(RouteAttribute), false)
+            .Cast<RouteAttribute>()
+            .Single();
+        Assert.AreEqual("api/capabilities", route.Template);
+        Assert.IsTrue(controllerType.IsDefined(typeof(AuthorizeAttribute), false));
+
+        var getMethod = controllerType.GetMethod(nameof(CapabilitiesController.Get));
+        Assert.IsNotNull(getMethod);
+        Assert.IsTrue(getMethod.IsDefined(typeof(HttpGetAttribute), false));
+
+        var json = JsonSerializer.Serialize(new RealtimeCapabilitiesDto
+        {
+            SignalR = true,
+            Push = new PushCapabilitiesDto { Fcm = false }
+        });
+        using var document = JsonDocument.Parse(json);
+        var root = document.RootElement;
+        Assert.IsTrue(root.GetProperty("signalR").GetBoolean());
+        Assert.IsFalse(root.GetProperty("push").GetProperty("fcm").GetBoolean());
+    }
+}

--- a/src/SyncClipboard.Test/CapabilitiesControllerTests.cs
+++ b/src/SyncClipboard.Test/CapabilitiesControllerTests.cs
@@ -1,8 +1,10 @@
 using System.Text.Json;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc;
+using Moq;
 using SyncClipboard.Server.Core.Controllers;
 using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
 
 namespace SyncClipboard.Test;
 
@@ -12,7 +14,9 @@ public class CapabilitiesControllerTests
     [TestMethod]
     public void Get_ReturnsCurrentRealtimeTransportCapabilities()
     {
-        var controller = new CapabilitiesController();
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(false);
+        var controller = new CapabilitiesController(fcmClient.Object);
 
         var result = controller.Get();
 
@@ -22,6 +26,21 @@ public class CapabilitiesControllerTests
         Assert.IsNotNull(capabilities);
         Assert.IsTrue(capabilities.SignalR);
         Assert.IsFalse(capabilities.Push.Fcm);
+    }
+
+    [TestMethod]
+    public void Get_AdvertisesFcmOnlyWhenProviderIsAvailable()
+    {
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        var controller = new CapabilitiesController(fcmClient.Object);
+
+        var result = controller.Get();
+
+        var ok = result.Result as OkObjectResult;
+        var capabilities = ok?.Value as RealtimeCapabilitiesDto;
+        Assert.IsNotNull(capabilities);
+        Assert.IsTrue(capabilities.Push.Fcm);
     }
 
     [TestMethod]

--- a/src/SyncClipboard.Test/CompositeProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/CompositeProfileChangeNotifierTests.cs
@@ -1,0 +1,23 @@
+using Moq;
+using SyncClipboard.Server.Core.Services.Notifications;
+using SyncClipboard.Shared;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class CompositeProfileChangeNotifierTests
+{
+    [TestMethod]
+    public async Task NotifyProfileChanged_InvokesEveryProvider()
+    {
+        var signalR = new Mock<IProfileChangeNotifier>();
+        var fcm = new Mock<IProfileChangeNotifier>();
+        var notifier = new CompositeProfileChangeNotifier([signalR.Object, fcm.Object]);
+        var profile = new ProfileDto { Hash = "profile-hash" };
+
+        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+
+        signalR.Verify(value => value.NotifyProfileChanged(profile, CancellationToken.None), Times.Once);
+        fcm.Verify(value => value.NotifyProfileChanged(profile, CancellationToken.None), Times.Once);
+    }
+}

--- a/src/SyncClipboard.Test/CompositeProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/CompositeProfileChangeNotifierTests.cs
@@ -14,10 +14,13 @@ public class CompositeProfileChangeNotifierTests
         var fcm = new Mock<IProfileChangeNotifier>();
         var notifier = new CompositeProfileChangeNotifier([signalR.Object, fcm.Object]);
         var profile = new ProfileDto { Hash = "profile-hash" };
+        var notification = new ProfileChangeNotification(profile, "origin-device-id");
 
-        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+        await notifier.NotifyProfileChanged(notification, CancellationToken.None);
 
-        signalR.Verify(value => value.NotifyProfileChanged(profile, CancellationToken.None), Times.Once);
-        fcm.Verify(value => value.NotifyProfileChanged(profile, CancellationToken.None), Times.Once);
+        signalR.Verify(value => value.NotifyProfileChanged(
+            notification, CancellationToken.None), Times.Once);
+        fcm.Verify(value => value.NotifyProfileChanged(
+            notification, CancellationToken.None), Times.Once);
     }
 }

--- a/src/SyncClipboard.Test/FcmMessageFactoryTests.cs
+++ b/src/SyncClipboard.Test/FcmMessageFactoryTests.cs
@@ -1,0 +1,28 @@
+using FirebaseAdmin.Messaging;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class FcmMessageFactoryTests
+{
+    [TestMethod]
+    public void CreateProfileChangedMessage_UsesCollapsedNormalPriorityHashOnlyPayload()
+    {
+        var message = FcmMessageFactory.CreateProfileChangedMessage(
+            "push-token", "profile-hash");
+
+#pragma warning disable CS0618 // S4/M7 protocol intentionally targets an FCM registration token.
+        Assert.AreEqual("push-token", message.Token);
+#pragma warning restore CS0618
+        Assert.IsNull(message.Notification);
+        Assert.HasCount(3, message.Data);
+        Assert.AreEqual("1", message.Data["v"]);
+        Assert.AreEqual("clipboard_changed", message.Data["type"]);
+        Assert.AreEqual("profile-hash", message.Data["hash"]);
+        Assert.IsFalse(message.Data.ContainsKey("text"));
+        Assert.IsNotNull(message.Android);
+        Assert.AreEqual("clipboard", message.Android.CollapseKey);
+        Assert.AreEqual(Priority.Normal, message.Android.Priority);
+    }
+}

--- a/src/SyncClipboard.Test/FcmProfileChangeDeliveryTests.cs
+++ b/src/SyncClipboard.Test/FcmProfileChangeDeliveryTests.cs
@@ -1,0 +1,144 @@
+using Microsoft.Extensions.Logging;
+using Moq;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class FcmProfileChangeDeliveryTests
+{
+    [TestMethod]
+    public async Task DeliverAsync_SendsHashOnlyHintToEveryRegisteredDevice()
+    {
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration("device-a", "token-a"),
+            CreateRegistration("device-b", "token-b")
+        };
+        var registry = CreateRegistry(registrations);
+        var fcmClient = CreateAvailableClient();
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", null),
+            CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-a", "profile-hash", CancellationToken.None), Times.Once);
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-b", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliverAsync_ExcludesOriginatingDeviceOnly()
+    {
+        var originDeviceId = Guid.NewGuid().ToString("D");
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration(originDeviceId, "origin-token"),
+            CreateRegistration(Guid.NewGuid().ToString("D"), "other-token")
+        };
+        var registry = CreateRegistry(registrations);
+        var fcmClient = CreateAvailableClient();
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", originDeviceId.ToUpperInvariant()),
+            CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "origin-token", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "other-token", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliverAsync_WhenUnavailable_DoesNotReadRegistry()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(false);
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", null),
+            CancellationToken.None);
+
+        registry.Verify(value => value.GetByProviderAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeliverAsync_WhenOneSendFails_ContinuesOtherDevices()
+    {
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration("device-a", "token-a"),
+            CreateRegistration("device-b", "token-b")
+        };
+        var registry = CreateRegistry(registrations);
+        var fcmClient = CreateAvailableClient();
+        fcmClient.Setup(value => value.SendProfileChangedAsync(
+                "token-a", "profile-hash", CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("send failed"));
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", null),
+            CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-b", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task DeliverAsync_WhenRegistryFails_DoesNotSend()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("registry failed"));
+        var fcmClient = CreateAvailableClient();
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", null),
+            CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static FcmProfileChangeDelivery CreateDelivery(
+        Mock<IPushDeviceRegistry> registry,
+        Mock<IFcmPushClient> fcmClient)
+    {
+        return new FcmProfileChangeDelivery(
+            registry.Object,
+            fcmClient.Object,
+            Mock.Of<ILogger<FcmProfileChangeDelivery>>());
+    }
+
+    private static Mock<IPushDeviceRegistry> CreateRegistry(
+        IReadOnlyList<PushDeviceRegistration> registrations)
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ReturnsAsync(registrations);
+        return registry;
+    }
+
+    private static Mock<IFcmPushClient> CreateAvailableClient()
+    {
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        return fcmClient;
+    }
+
+    private static PushDeviceRegistration CreateRegistration(string deviceId, string pushToken)
+    {
+        return new PushDeviceRegistration(
+            deviceId, "android", "fcm", pushToken, "1.0.0", DateTimeOffset.UtcNow);
+    }
+}

--- a/src/SyncClipboard.Test/FcmProfileChangeDeliveryTests.cs
+++ b/src/SyncClipboard.Test/FcmProfileChangeDeliveryTests.cs
@@ -71,7 +71,7 @@ public class FcmProfileChangeDeliveryTests
     }
 
     [TestMethod]
-    public async Task DeliverAsync_WhenOneSendFails_ContinuesOtherDevices()
+    public async Task DeliverAsync_WhenOneSendFails_ContinuesOtherDevicesWithoutRemovingRegistration()
     {
         var registrations = new List<PushDeviceRegistration>
         {
@@ -91,6 +91,37 @@ public class FcmProfileChangeDeliveryTests
 
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             "token-b", "profile-hash", CancellationToken.None), Times.Once);
+        registry.Verify(value => value.RemoveIfTokenMatchesAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task DeliverAsync_WhenRegistrationIsPermanentlyInvalid_RemovesOnlyMatchingToken()
+    {
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration("device-a", "stale-token"),
+            CreateRegistration("device-b", "valid-token")
+        };
+        var registry = CreateRegistry(registrations);
+        registry.Setup(value => value.RemoveIfTokenMatchesAsync(
+                "device-a", "stale-token", CancellationToken.None))
+            .ReturnsAsync(true);
+        var fcmClient = CreateAvailableClient();
+        fcmClient.Setup(value => value.SendProfileChangedAsync(
+                "stale-token", "profile-hash", CancellationToken.None))
+            .ThrowsAsync(new InvalidFcmRegistrationException(
+                "unregistered", new InvalidOperationException()));
+        var delivery = CreateDelivery(registry, fcmClient);
+
+        await delivery.DeliverAsync(
+            new FcmProfileChangeHint("profile-hash", null),
+            CancellationToken.None);
+
+        registry.Verify(value => value.RemoveIfTokenMatchesAsync(
+            "device-a", "stale-token", CancellationToken.None), Times.Once);
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "valid-token", "profile-hash", CancellationToken.None), Times.Once);
     }
 
     [TestMethod]

--- a/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
@@ -1,0 +1,107 @@
+using Moq;
+using Microsoft.Extensions.Logging;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
+using SyncClipboard.Server.Core.Services.PushDevices;
+using SyncClipboard.Shared;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class FcmProfileChangeNotifierTests
+{
+    [TestMethod]
+    public async Task NotifyProfileChanged_SendsHashOnlyHintToEveryRegisteredDevice()
+    {
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration("device-a", "token-a"),
+            CreateRegistration("device-b", "token-b")
+        };
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ReturnsAsync(registrations);
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        var notifier = new FcmProfileChangeNotifier(
+            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+        var profile = new ProfileDto
+        {
+            Hash = "profile-hash",
+            Text = "must-not-enter-push"
+        };
+
+        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-a", "profile-hash", CancellationToken.None), Times.Once);
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-b", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NotifyProfileChanged_WhenUnavailable_DoesNotReadRegistry()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(false);
+        var notifier = new FcmProfileChangeNotifier(
+            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+
+        await notifier.NotifyProfileChanged(
+            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+
+        registry.Verify(value => value.GetByProviderAsync(
+            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task NotifyProfileChanged_WhenOneSendFails_ContinuesOtherDevices()
+    {
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration("device-a", "token-a"),
+            CreateRegistration("device-b", "token-b")
+        };
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ReturnsAsync(registrations);
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        fcmClient.Setup(value => value.SendProfileChangedAsync(
+                "token-a", "profile-hash", CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("send failed"));
+        var notifier = new FcmProfileChangeNotifier(
+            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+
+        await notifier.NotifyProfileChanged(
+            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "token-b", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NotifyProfileChanged_WhenRegistryFails_DoesNotFailProfileUpdate()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ThrowsAsync(new InvalidOperationException("registry failed"));
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        var notifier = new FcmProfileChangeNotifier(
+            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+
+        await notifier.NotifyProfileChanged(
+            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    private static PushDeviceRegistration CreateRegistration(string deviceId, string pushToken)
+    {
+        return new PushDeviceRegistration(
+            deviceId, "android", "fcm", pushToken, "1.0.0", DateTimeOffset.UtcNow);
+    }
+}

--- a/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
@@ -1,9 +1,7 @@
-using Moq;
 using Microsoft.Extensions.Logging;
-using SyncClipboard.Server.Core.Models;
+using Moq;
 using SyncClipboard.Server.Core.Services.Notifications;
 using SyncClipboard.Server.Core.Services.Notifications.Fcm;
-using SyncClipboard.Server.Core.Services.PushDevices;
 using SyncClipboard.Shared;
 
 namespace SyncClipboard.Test;
@@ -12,130 +10,64 @@ namespace SyncClipboard.Test;
 public class FcmProfileChangeNotifierTests
 {
     [TestMethod]
-    public async Task NotifyProfileChanged_SendsHashOnlyHintToEveryRegisteredDevice()
+    public async Task NotifyProfileChanged_QueuesHashAndOriginWithoutWaitingForDelivery()
     {
-        var registrations = new List<PushDeviceRegistration>
-        {
-            CreateRegistration("device-a", "token-a"),
-            CreateRegistration("device-b", "token-b")
-        };
-        var registry = new Mock<IPushDeviceRegistry>();
-        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
-            .ReturnsAsync(registrations);
+        var queue = new Mock<IFcmProfileChangeQueue>();
+        queue.Setup(value => value.TryEnqueue(It.IsAny<FcmProfileChangeHint>()))
+            .Returns(true);
         var fcmClient = new Mock<IFcmPushClient>();
         fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
         var notifier = new FcmProfileChangeNotifier(
-            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
-        var profile = new ProfileDto
-        {
-            Hash = "profile-hash",
-            Text = "must-not-enter-push"
-        };
+            queue.Object,
+            fcmClient.Object,
+            Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+        var notification = new ProfileChangeNotification(
+            new ProfileDto
+            {
+                Hash = "profile-hash",
+                Text = "must-not-enter-push"
+            },
+            "origin-device");
 
-        await notifier.NotifyProfileChanged(
-            new ProfileChangeNotification(profile), CancellationToken.None);
+        var notifyTask = notifier.NotifyProfileChanged(notification, CancellationToken.None);
 
-        fcmClient.Verify(value => value.SendProfileChangedAsync(
-            "token-a", "profile-hash", CancellationToken.None), Times.Once);
-        fcmClient.Verify(value => value.SendProfileChangedAsync(
-            "token-b", "profile-hash", CancellationToken.None), Times.Once);
-    }
-
-    [TestMethod]
-    public async Task NotifyProfileChanged_ExcludesOriginatingDeviceOnly()
-    {
-        var originDeviceId = Guid.NewGuid().ToString("D");
-        var registrations = new List<PushDeviceRegistration>
-        {
-            CreateRegistration(originDeviceId, "origin-token"),
-            CreateRegistration(Guid.NewGuid().ToString("D"), "other-token")
-        };
-        var registry = new Mock<IPushDeviceRegistry>();
-        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
-            .ReturnsAsync(registrations);
-        var fcmClient = new Mock<IFcmPushClient>();
-        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
-        var notifier = new FcmProfileChangeNotifier(
-            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
-
-        await notifier.NotifyProfileChanged(
-            new ProfileChangeNotification(
-                new ProfileDto { Hash = "profile-hash" },
-                originDeviceId.ToUpperInvariant()),
-            CancellationToken.None);
-
-        fcmClient.Verify(value => value.SendProfileChangedAsync(
-            "origin-token", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-        fcmClient.Verify(value => value.SendProfileChangedAsync(
-            "other-token", "profile-hash", CancellationToken.None), Times.Once);
-    }
-
-    [TestMethod]
-    public async Task NotifyProfileChanged_WhenUnavailable_DoesNotReadRegistry()
-    {
-        var registry = new Mock<IPushDeviceRegistry>();
-        var fcmClient = new Mock<IFcmPushClient>();
-        fcmClient.SetupGet(value => value.IsAvailable).Returns(false);
-        var notifier = new FcmProfileChangeNotifier(
-            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
-
-        await notifier.NotifyProfileChanged(
-            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
-            CancellationToken.None);
-
-        registry.Verify(value => value.GetByProviderAsync(
-            It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
-    }
-
-    [TestMethod]
-    public async Task NotifyProfileChanged_WhenOneSendFails_ContinuesOtherDevices()
-    {
-        var registrations = new List<PushDeviceRegistration>
-        {
-            CreateRegistration("device-a", "token-a"),
-            CreateRegistration("device-b", "token-b")
-        };
-        var registry = new Mock<IPushDeviceRegistry>();
-        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
-            .ReturnsAsync(registrations);
-        var fcmClient = new Mock<IFcmPushClient>();
-        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
-        fcmClient.Setup(value => value.SendProfileChangedAsync(
-                "token-a", "profile-hash", CancellationToken.None))
-            .ThrowsAsync(new InvalidOperationException("send failed"));
-        var notifier = new FcmProfileChangeNotifier(
-            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
-
-        await notifier.NotifyProfileChanged(
-            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
-            CancellationToken.None);
-
-        fcmClient.Verify(value => value.SendProfileChangedAsync(
-            "token-b", "profile-hash", CancellationToken.None), Times.Once);
-    }
-
-    [TestMethod]
-    public async Task NotifyProfileChanged_WhenRegistryFails_DoesNotFailProfileUpdate()
-    {
-        var registry = new Mock<IPushDeviceRegistry>();
-        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
-            .ThrowsAsync(new InvalidOperationException("registry failed"));
-        var fcmClient = new Mock<IFcmPushClient>();
-        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
-        var notifier = new FcmProfileChangeNotifier(
-            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
-
-        await notifier.NotifyProfileChanged(
-            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
-            CancellationToken.None);
-
+        Assert.IsTrue(notifyTask.IsCompletedSuccessfully);
+        await notifyTask;
+        queue.Verify(value => value.TryEnqueue(
+            new FcmProfileChangeHint("profile-hash", "origin-device")), Times.Once);
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
     }
 
-    private static PushDeviceRegistration CreateRegistration(string deviceId, string pushToken)
+    [TestMethod]
+    public async Task NotifyProfileChanged_WhenUnavailable_DoesNotQueue()
     {
-        return new PushDeviceRegistration(
-            deviceId, "android", "fcm", pushToken, "1.0.0", DateTimeOffset.UtcNow);
+        var queue = new Mock<IFcmProfileChangeQueue>();
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(false);
+        var notifier = new FcmProfileChangeNotifier(
+            queue.Object,
+            fcmClient.Object,
+            Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+
+        await notifier.NotifyProfileChanged(
+            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
+            CancellationToken.None);
+
+        queue.Verify(value => value.TryEnqueue(
+            It.IsAny<FcmProfileChangeHint>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Queue_WhenFull_KeepsLatestProfileChange()
+    {
+        var queue = new FcmProfileChangeQueue();
+        Assert.IsTrue(queue.TryEnqueue(new FcmProfileChangeHint("hash-a", null)));
+        Assert.IsTrue(queue.TryEnqueue(new FcmProfileChangeHint("hash-b", "device-b")));
+        Assert.IsTrue(queue.TryEnqueue(new FcmProfileChangeHint("hash-c", "device-c")));
+
+        var hint = await queue.DequeueAsync(CancellationToken.None);
+
+        Assert.AreEqual(new FcmProfileChangeHint("hash-c", "device-c"), hint);
     }
 }

--- a/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/FcmProfileChangeNotifierTests.cs
@@ -1,6 +1,7 @@
 using Moq;
 using Microsoft.Extensions.Logging;
 using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications;
 using SyncClipboard.Server.Core.Services.Notifications.Fcm;
 using SyncClipboard.Server.Core.Services.PushDevices;
 using SyncClipboard.Shared;
@@ -31,12 +32,42 @@ public class FcmProfileChangeNotifierTests
             Text = "must-not-enter-push"
         };
 
-        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+        await notifier.NotifyProfileChanged(
+            new ProfileChangeNotification(profile), CancellationToken.None);
 
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             "token-a", "profile-hash", CancellationToken.None), Times.Once);
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             "token-b", "profile-hash", CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task NotifyProfileChanged_ExcludesOriginatingDeviceOnly()
+    {
+        var originDeviceId = Guid.NewGuid().ToString("D");
+        var registrations = new List<PushDeviceRegistration>
+        {
+            CreateRegistration(originDeviceId, "origin-token"),
+            CreateRegistration(Guid.NewGuid().ToString("D"), "other-token")
+        };
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.GetByProviderAsync("fcm", CancellationToken.None))
+            .ReturnsAsync(registrations);
+        var fcmClient = new Mock<IFcmPushClient>();
+        fcmClient.SetupGet(value => value.IsAvailable).Returns(true);
+        var notifier = new FcmProfileChangeNotifier(
+            registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
+
+        await notifier.NotifyProfileChanged(
+            new ProfileChangeNotification(
+                new ProfileDto { Hash = "profile-hash" },
+                originDeviceId.ToUpperInvariant()),
+            CancellationToken.None);
+
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "origin-token", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
+        fcmClient.Verify(value => value.SendProfileChangedAsync(
+            "other-token", "profile-hash", CancellationToken.None), Times.Once);
     }
 
     [TestMethod]
@@ -49,7 +80,8 @@ public class FcmProfileChangeNotifierTests
             registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
 
         await notifier.NotifyProfileChanged(
-            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
+            CancellationToken.None);
 
         registry.Verify(value => value.GetByProviderAsync(
             It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);
@@ -75,7 +107,8 @@ public class FcmProfileChangeNotifierTests
             registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
 
         await notifier.NotifyProfileChanged(
-            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
+            CancellationToken.None);
 
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             "token-b", "profile-hash", CancellationToken.None), Times.Once);
@@ -93,7 +126,8 @@ public class FcmProfileChangeNotifierTests
             registry.Object, fcmClient.Object, Mock.Of<ILogger<FcmProfileChangeNotifier>>());
 
         await notifier.NotifyProfileChanged(
-            new ProfileDto { Hash = "profile-hash" }, CancellationToken.None);
+            new ProfileChangeNotification(new ProfileDto { Hash = "profile-hash" }),
+            CancellationToken.None);
 
         fcmClient.Verify(value => value.SendProfileChangedAsync(
             It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Never);

--- a/src/SyncClipboard.Test/FirebaseAdminFcmPushClientTests.cs
+++ b/src/SyncClipboard.Test/FirebaseAdminFcmPushClientTests.cs
@@ -1,0 +1,23 @@
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.Notifications.Fcm;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class FirebaseAdminFcmPushClientTests
+{
+    [TestMethod]
+    public async Task DisabledConfiguration_RemainsUnavailableWithoutCredentials()
+    {
+        using var client = new FirebaseAdminFcmPushClient(
+            Options.Create(new AppSettings { EnableFcmPush = false }),
+            NullLogger<FirebaseAdminFcmPushClient>.Instance);
+
+        Assert.IsFalse(client.IsAvailable);
+        await Assert.ThrowsExactlyAsync<InvalidOperationException>(() =>
+            client.SendProfileChangedAsync(
+                "push-token", "profile-hash", CancellationToken.None));
+    }
+}

--- a/src/SyncClipboard.Test/PushDeviceRegistryTests.cs
+++ b/src/SyncClipboard.Test/PushDeviceRegistryTests.cs
@@ -1,0 +1,88 @@
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.Data.Sqlite;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using SyncClipboard.Server.Core.Services;
+using SyncClipboard.Server.Core.Services.PushDevices;
+using SyncClipboard.Server.Core.Utilities.History;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class PushDeviceRegistryTests
+{
+    [TestMethod]
+    public async Task UpsertAsync_ReplacesRegistrationForSameDevice()
+    {
+        await using var harness = await RegistryHarness.Create();
+        var deviceId = Guid.NewGuid().ToString("D");
+
+        await harness.Registry.UpsertAsync(
+            deviceId, "android", "fcm", "old-token", "1.0.0", CancellationToken.None);
+        await harness.Registry.UpsertAsync(
+            deviceId, "android", "fcm", "new-token", "2.0.0", CancellationToken.None);
+
+        var registrations = await harness.Registry.GetByProviderAsync("fcm", CancellationToken.None);
+        Assert.HasCount(1, registrations);
+        var registration = registrations[0];
+        Assert.AreEqual(deviceId, registration.DeviceId);
+        Assert.AreEqual("android", registration.Platform);
+        Assert.AreEqual("fcm", registration.Provider);
+        Assert.AreEqual("new-token", registration.PushToken);
+        Assert.AreEqual("2.0.0", registration.AppVersion);
+        Assert.IsTrue(registration.LastUpdated <= DateTimeOffset.UtcNow);
+    }
+
+    [TestMethod]
+    public async Task RemoveAsync_IsIdempotent()
+    {
+        await using var harness = await RegistryHarness.Create();
+        var deviceId = Guid.NewGuid().ToString("D");
+        await harness.Registry.UpsertAsync(
+            deviceId, "android", "fcm", "push-token", null, CancellationToken.None);
+
+        Assert.IsTrue(await harness.Registry.RemoveAsync(deviceId, CancellationToken.None));
+        Assert.IsFalse(await harness.Registry.RemoveAsync(deviceId, CancellationToken.None));
+    }
+
+    private sealed class RegistryHarness : IAsyncDisposable
+    {
+        private readonly SqliteConnection _connection;
+        private readonly HistoryDbContext _dbContext;
+
+        private RegistryHarness(
+            SqliteConnection connection,
+            HistoryDbContext dbContext,
+            PushDeviceRegistry registry)
+        {
+            _connection = connection;
+            _dbContext = dbContext;
+            Registry = registry;
+        }
+
+        public PushDeviceRegistry Registry { get; }
+
+        public static async Task<RegistryHarness> Create()
+        {
+            var connection = new SqliteConnection("Data Source=:memory:");
+            await connection.OpenAsync();
+            var options = new DbContextOptionsBuilder<HistoryDbContext>()
+                .UseSqlite(connection)
+                .Options;
+            var environment = new Mock<IWebHostEnvironment>();
+            environment.SetupGet(value => value.ContentRootPath).Returns(Path.GetTempPath());
+            var dbContext = new HistoryDbContext(options, new ServerEnvProvider(environment.Object));
+            await dbContext.Database.MigrateAsync();
+            var registry = new PushDeviceRegistry(
+                dbContext, NullLogger<PushDeviceRegistry>.Instance);
+            return new RegistryHarness(connection, dbContext, registry);
+        }
+
+        public async ValueTask DisposeAsync()
+        {
+            await _dbContext.DisposeAsync();
+            await _connection.DisposeAsync();
+        }
+    }
+}

--- a/src/SyncClipboard.Test/PushDeviceRegistryTests.cs
+++ b/src/SyncClipboard.Test/PushDeviceRegistryTests.cs
@@ -46,6 +46,23 @@ public class PushDeviceRegistryTests
         Assert.IsFalse(await harness.Registry.RemoveAsync(deviceId, CancellationToken.None));
     }
 
+    [TestMethod]
+    public async Task RemoveIfTokenMatchesAsync_DoesNotRemoveRotatedToken()
+    {
+        await using var harness = await RegistryHarness.Create();
+        var deviceId = Guid.NewGuid().ToString("D");
+        await harness.Registry.UpsertAsync(
+            deviceId, "android", "fcm", "new-token", null, CancellationToken.None);
+
+        var removed = await harness.Registry.RemoveIfTokenMatchesAsync(
+            deviceId, "old-token", CancellationToken.None);
+
+        Assert.IsFalse(removed);
+        var registrations = await harness.Registry.GetByProviderAsync("fcm", CancellationToken.None);
+        Assert.HasCount(1, registrations);
+        Assert.AreEqual("new-token", registrations[0].PushToken);
+    }
+
     private sealed class RegistryHarness : IAsyncDisposable
     {
         private readonly SqliteConnection _connection;

--- a/src/SyncClipboard.Test/PushDevicesControllerTests.cs
+++ b/src/SyncClipboard.Test/PushDevicesControllerTests.cs
@@ -1,0 +1,118 @@
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using SyncClipboard.Server.Core.Controllers;
+using SyncClipboard.Server.Core.Models;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class PushDevicesControllerTests
+{
+    [TestMethod]
+    public async Task Put_NormalizesAndRegistersSupportedDevice()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        var controller = new PushDevicesController(registry.Object);
+        var deviceId = Guid.NewGuid();
+        var request = new PushDeviceRegistrationRequest
+        {
+            Platform = "ANDROID",
+            Provider = "FCM",
+            Token = " push-token ",
+            AppVersion = " 1.2.3 "
+        };
+
+        var result = await controller.Put(deviceId.ToString("B"), request, CancellationToken.None);
+
+        Assert.IsInstanceOfType<NoContentResult>(result);
+        registry.Verify(value => value.UpsertAsync(
+            deviceId.ToString("D"),
+            "android",
+            "fcm",
+            "push-token",
+            "1.2.3",
+            CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public async Task Put_RejectsInvalidRegistrationWithoutWriting()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        var controller = new PushDevicesController(registry.Object);
+        var request = new PushDeviceRegistrationRequest
+        {
+            Platform = "android",
+            Provider = "apns",
+            Token = "push-token"
+        };
+
+        var result = await controller.Put(Guid.NewGuid().ToString(), request, CancellationToken.None);
+
+        Assert.IsInstanceOfType<BadRequestObjectResult>(result);
+        registry.Verify(value => value.UpsertAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Put_RejectsInvalidDeviceIdWithoutWriting()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        var controller = new PushDevicesController(registry.Object);
+        var request = new PushDeviceRegistrationRequest
+        {
+            Platform = "android",
+            Provider = "fcm",
+            Token = "push-token"
+        };
+
+        var result = await controller.Put("not-a-uuid", request, CancellationToken.None);
+
+        Assert.IsInstanceOfType<BadRequestObjectResult>(result);
+        registry.Verify(value => value.UpsertAsync(
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string?>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [TestMethod]
+    public async Task Delete_IsIdempotentAndNormalizesDeviceId()
+    {
+        var registry = new Mock<IPushDeviceRegistry>();
+        registry.Setup(value => value.RemoveAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        var controller = new PushDevicesController(registry.Object);
+        var deviceId = Guid.NewGuid();
+
+        var result = await controller.Delete(deviceId.ToString("B"), CancellationToken.None);
+
+        Assert.IsInstanceOfType<NoContentResult>(result);
+        registry.Verify(value => value.RemoveAsync(
+            deviceId.ToString("D"), CancellationToken.None), Times.Once);
+    }
+
+    [TestMethod]
+    public void Contract_UsesAuthenticatedPushRegistrationRoute()
+    {
+        var controllerType = typeof(PushDevicesController);
+        var route = controllerType.GetCustomAttributes(typeof(RouteAttribute), false)
+            .Cast<RouteAttribute>()
+            .Single();
+
+        Assert.AreEqual("api/devices/{deviceId}/push", route.Template);
+        Assert.IsTrue(controllerType.IsDefined(typeof(AuthorizeAttribute), false));
+        Assert.IsTrue(controllerType.GetMethod(nameof(PushDevicesController.Put))!
+            .IsDefined(typeof(HttpPutAttribute), false));
+        Assert.IsTrue(controllerType.GetMethod(nameof(PushDevicesController.Delete))!
+            .IsDefined(typeof(HttpDeleteAttribute), false));
+    }
+}

--- a/src/SyncClipboard.Test/SignalRProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/SignalRProfileChangeNotifierTests.cs
@@ -1,0 +1,33 @@
+using Microsoft.AspNetCore.SignalR;
+using Moq;
+using SyncClipboard.Server.Core.Hubs;
+using SyncClipboard.Server.Core.Services.Notifications;
+using SyncClipboard.Shared;
+using SyncClipboard.Shared.Profiles;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class SignalRProfileChangeNotifierTests
+{
+    [TestMethod]
+    public async Task NotifyProfileChanged_BroadcastsProfileToAllSignalRClients()
+    {
+        var profile = new ProfileDto
+        {
+            Type = ProfileType.Text,
+            Hash = "profile-hash",
+            Text = "clipboard"
+        };
+        var client = new Mock<ISyncClipboardClient>();
+        var clients = new Mock<IHubClients<ISyncClipboardClient>>();
+        clients.SetupGet(value => value.All).Returns(client.Object);
+        var hubContext = new Mock<IHubContext<SyncClipboardHub, ISyncClipboardClient>>();
+        hubContext.SetupGet(value => value.Clients).Returns(clients.Object);
+        var notifier = new SignalRProfileChangeNotifier(hubContext.Object);
+
+        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+
+        client.Verify(value => value.RemoteProfileChanged(profile), Times.Once);
+    }
+}

--- a/src/SyncClipboard.Test/SignalRProfileChangeNotifierTests.cs
+++ b/src/SyncClipboard.Test/SignalRProfileChangeNotifierTests.cs
@@ -26,7 +26,9 @@ public class SignalRProfileChangeNotifierTests
         hubContext.SetupGet(value => value.Clients).Returns(clients.Object);
         var notifier = new SignalRProfileChangeNotifier(hubContext.Object);
 
-        await notifier.NotifyProfileChanged(profile, CancellationToken.None);
+        await notifier.NotifyProfileChanged(
+            new ProfileChangeNotification(profile, "origin-device-id"),
+            CancellationToken.None);
 
         client.Verify(value => value.RemoteProfileChanged(profile), Times.Once);
     }

--- a/src/SyncClipboard.Test/SyncClipboard.Test.csproj
+++ b/src/SyncClipboard.Test/SyncClipboard.Test.csproj
@@ -15,6 +15,7 @@
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="MSTest.TestAdapter" />
     <PackageReference Include="MSTest.TestFramework" />
+    <PackageReference Include="Moq" />
     <PackageReference Include="coverlet.collector">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/src/SyncClipboard.Test/SyncDeviceIdentityTests.cs
+++ b/src/SyncClipboard.Test/SyncDeviceIdentityTests.cs
@@ -1,0 +1,42 @@
+using Microsoft.AspNetCore.Mvc;
+using SyncClipboard.Server.Core.Controllers;
+using SyncClipboard.Server.Core.Services.PushDevices;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class SyncDeviceIdentityTests
+{
+    [TestMethod]
+    public void Normalize_ValidUuid_ReturnsCanonicalDeviceId()
+    {
+        var deviceId = Guid.NewGuid();
+
+        var normalized = SyncDeviceIdentity.Normalize(deviceId.ToString("B").ToUpperInvariant());
+
+        Assert.AreEqual(deviceId.ToString("D"), normalized);
+    }
+
+    [TestMethod]
+    public void Normalize_InvalidOrMissingUuid_ReturnsNull()
+    {
+        Assert.IsNull(SyncDeviceIdentity.Normalize(null));
+        Assert.IsNull(SyncDeviceIdentity.Normalize("not-a-uuid"));
+    }
+
+    [TestMethod]
+    public void PutSyncProfile_BindsOriginFromStableDeviceIdHeader()
+    {
+        var parameter = typeof(SyncClipboardController)
+            .GetMethod(nameof(SyncClipboardController.PutSyncProfile))!
+            .GetParameters()
+            .Single(value => value.Name == "originDeviceId");
+        var attribute = parameter
+            .GetCustomAttributes(typeof(FromHeaderAttribute), false)
+            .Cast<FromHeaderAttribute>()
+            .Single();
+
+        Assert.AreEqual(SyncDeviceIdentity.HeaderName, attribute.Name);
+        Assert.AreEqual("X-SyncClipboard-Device-Id", attribute.Name);
+    }
+}

--- a/src/SyncClipboard.Test/WebTests.cs
+++ b/src/SyncClipboard.Test/WebTests.cs
@@ -1,0 +1,39 @@
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Options;
+using SyncClipboard.Server.Core;
+using SyncClipboard.Server.Core.Models;
+
+namespace SyncClipboard.Test;
+
+[TestClass]
+public class WebTests
+{
+    [TestMethod]
+    public void ConfigureEmbeddedServerAppSettings_BindsFcmAndOverridesHistorySettings()
+    {
+        var configuration = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["AppSettings:EnableFcmPush"] = "true",
+                ["AppSettings:FirebaseProjectId"] = "configured-project",
+                ["AppSettings:MaxSavedHistoryCount"] = "1",
+                ["AppSettings:HistoryRetentionMinutes"] = "2"
+            })
+            .Build();
+        var services = new ServiceCollection();
+
+        Web.ConfigureEmbeddedServerAppSettings(
+            services,
+            configuration,
+            maxSavedHistoryCount: 300,
+            historyRetentionMinutes: 400);
+
+        using var provider = services.BuildServiceProvider();
+        var settings = provider.GetRequiredService<IOptions<AppSettings>>().Value;
+        Assert.IsTrue(settings.EnableFcmPush);
+        Assert.AreEqual("configured-project", settings.FirebaseProjectId);
+        Assert.AreEqual(300u, settings.MaxSavedHistoryCount);
+        Assert.AreEqual(400u, settings.HistoryRetentionMinutes);
+    }
+}


### PR DESCRIPTION
## Summary

Add optional FCM profile-change notifications while preserving SignalR as the existing realtime transport.

This PR keeps HTTP profile state authoritative. FCM carries only a change hint (`v`, `type`, and `hash`), never clipboard text, images, files, or a full profile.

## What changed

- route profile-change fanout through `IProfileChangeNotifier`, with the current SignalR behavior retained
- expose realtime capabilities so old servers naturally remain push-unsupported
- add an idempotent Android push-device registry and token replacement by `deviceId`
- add an optional Firebase Admin provider using normal priority and the `clipboard` collapse key
- fan out through both SignalR and FCM when FCM is configured
- accept `X-SyncClipboard-Device-Id` and skip echo push to the originating Android device

Firebase is disabled unless valid server configuration is supplied. Existing desktop clients, mobile clients, and SignalR behavior are otherwise unchanged.

## Compatibility and security

- old clients do not need to call the new endpoints
- a missing/disabled Firebase configuration leaves SignalR behavior intact
- device registrations store delivery metadata only, not clipboard content
- the push payload contains no clipboard content

## Companion client

Android client PR: https://github.com/Jeric-X/syncclipboard-mobile/pull/48

Old mobile clients remain compatible with this server PR.

## Validation

- `dotnet build src/SyncClipboard.Server --no-restore` — passed, 0 warnings / 0 errors
- `DOTNET_ROLL_FORWARD=Major dotnet test src/SyncClipboard.Test --no-restore` — 148/148 passed
- `dotnet format src/SyncClipboard.Server.Core/SyncClipboard.Server.Core.csproj --verify-no-changes --severity info --no-restore` — passed
- `git diff --check` — passed

The test command used major roll-forward because the local host has .NET 10 but not the project's .NET 8 runtime; the test assembly still targets `net8.0`.
